### PR TITLE
Add "Converter" setting (Set to FURNACE or STONECUTTER) (resolve #44)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 /bin
+/references/*.jar

--- a/references/requirements.md
+++ b/references/requirements.md
@@ -1,0 +1,15 @@
+You must download the following files to the references folder:
+- BungeeCord.jar
+  - from <https://ci.md-5.net/job/BungeeCord/>
+- [https://hub.spigotmc.org/nexus/content/repositories/snapshots/org/spigotmc/spigot-api/1.19.2-R0.1-SNAPSHOT/spigot-api-1.19.2-R0.1-20221106.071812-39.jar](spigot-api-1.19.2-R0.1-20221106.071812-39.jar)
+  - from <https://hub.spigotmc.org/nexus/content/repositories/snapshots/org/spigotmc/spigot-api/1.19.2-R0.1-SNAPSHOT/>
+- PlaceholderAPI-2.11.2.jar
+  (or later version that works with your Minecraft version)
+  - from <https://www.spigotmc.org/resources/placeholderapi.6245/>
+- AdvancedEnchantments-8.7.4.jar
+  - from <https://www.spigotmc.org/resources/advancedenchantments-api.76819/update?update=429059>
+
+If you use different versions, you must change the paths.
+- Eclipse:
+  - Right-click project "Custom Recipes" at top left.
+  - Java Build Path, Libraries tab, then double-click to choose the file in each case where the jar is missing.

--- a/src/me/mehboss/recipe/EffectsManager.java
+++ b/src/me/mehboss/recipe/EffectsManager.java
@@ -33,28 +33,22 @@ public class EffectsManager implements Listener {
 		return YamlConfiguration.loadConfiguration(recipeFile);
 	}
 
-	public boolean isVersion() {
-		String version = Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
-
-		if (version.contains("1_7") || version.contains("1_8") || version.contains("1_9") || version.contains("1_10")
-				|| version.contains("1_11") || version.contains("1_12"))
-			return false;
-
-		return true;
+	public boolean versionHasTrident() {
+		return Main.serverVersionAtLeast(1, 13);
 	}
 
 	@SuppressWarnings("deprecation")
 	@EventHandler
 	public void oneffect(EntityDamageByEntityEvent p) {
 
-		if (p.getDamager() instanceof Player || (isVersion() && p.getDamager() instanceof Trident)) {
+		if (p.getDamager() instanceof Player || (versionHasTrident() && p.getDamager() instanceof Trident)) {
 
 			Player pl = null;
 
 			if (p.getDamager() instanceof Player)
 				pl = (Player) p.getDamager();
 
-			if (isVersion() && p.getDamager() instanceof Trident) {
+			if (versionHasTrident() && p.getDamager() instanceof Trident) {
 				Projectile trident = (Projectile) p.getDamager();
 				pl = trident.getShooter() instanceof Player ? (Player) trident.getShooter() : null;
 			}
@@ -99,7 +93,7 @@ public class EffectsManager implements Listener {
 					PotionEffect effect = new PotionEffect(PotionEffectType.getByName(eff), duration, amplifier);
 					LivingEntity l = (LivingEntity) p.getEntity();
 
-					if (validVersion() && l instanceof Player && ((Player) l).isBlocking())
+					if (versionHasBlocking() && l instanceof Player && ((Player) l).isBlocking())
 						return;
 
 					l.addPotionEffect(effect);
@@ -108,12 +102,12 @@ public class EffectsManager implements Listener {
 		}
 	}
 
-	boolean validVersion() {
-		String version = Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
-		if (version.contains("1_7") || version.contains("1_8") || version.contains("1_9"))
-			return false;
-
-		return true;
+	boolean versionHasBlocking() {
+		// - In 1.9 sword blocking was replaced by shield blocking.
+		// - In 1.11 shields block 100% damage/knockback/debuff
+		// - However, this function only checked for 1_7 to 1_9 as false
+		//   so only those are avoided in the new serverVersionAtLeast call.
+		return Main.serverVersionAtLeast(1, 10);
 	}
 
 	HashMap<String, ItemStack> identifier() {

--- a/src/me/mehboss/recipe/Main.java
+++ b/src/me/mehboss/recipe/Main.java
@@ -369,10 +369,7 @@ public class Main extends JavaPlugin implements Listener {
 		PluginCommand crecipeCommand = getCommand("crecipe");
 		crecipeCommand.setExecutor(new GiveRecipe(this));
 
-		String version = Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
-		if (!version.contains("1_14") && !version.contains("1_13") && !version.contains("1_12")
-				&& !version.contains("1_11") && !version.contains("1_10") && !version.contains("1_9")
-				&& !version.contains("1_8") && !version.contains("1_7")) {
+		if (Main.serverVersionAtLeast(1, 15)) {
 			TabCompletion tabCompleter = new TabCompletion();
 			crecipeCommand.setTabCompleter(tabCompleter);
 		}
@@ -539,5 +536,62 @@ public class Main extends JavaPlugin implements Listener {
 							"&cCustom-Recipes: &fAn update has been found. Please download version&c " + newupdate
 									+ ", &fyou are on version&c " + getDescription().getVersion() + "!"));
 		}
+	}
+
+	private int[] getServerVersionParts() {
+		String version = Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
+		// ^ such as v1_20_R1
+		// which is [3] in dot-delimited "org.bukkit.craftbukkit.v1_20_R1"
+		String[] version_parts = version.split("_");
+		int version_major = -1;
+		int version_minor = -1;
+		try {
+			if (version_parts[0].startsWith("v")) {
+				// This is expected--remove "v" before the version number:
+				version_parts[0] = version_parts[0].substring(1);
+			}
+			version_major = Integer.parseInt(version_parts[0]);
+		}
+		catch (NumberFormatException e) {
+			// leave it at -1. It is not a number.
+			Main.getInstance().getLogger().log(Level.WARNING, "The major version number could not be detected in the first number before '_' in \""+version+"\". You may get API errors later.");
+		}
+		if (version_parts.length > 1) {
+			try {
+				version_major = Integer.parseInt(version_parts[1]);
+			}
+			catch (NumberFormatException e) {
+				// leave it at -1. It is not a number.
+				Main.getInstance().getLogger().log(Level.WARNING, "The minor version number could not be detected in the first number after '_' in \""+version+"\". You may get API errors later.");
+			}
+		}
+		return new int[] {version_major, version_minor};
+	}
+
+	public static boolean serverVersionBelow(int majorVersion, int minorVersion) {
+		int[] version_numbers = instance.getServerVersionParts();
+		if (version_numbers[0] < 0 || version_numbers[1] < 0) {
+			// Allow this plugin to run new API calls even if version can't be detected
+			// (A warning should already have been shown by getServerVersionParts):
+			return false;
+		}
+		if (version_numbers[0] < majorVersion) {
+			return true;
+		}
+		if (version_numbers[1] < minorVersion) {
+			return true;
+		}
+		return false;
+	}
+
+	public static boolean serverVersionAtLeast(int majorVersion, int minorVersion) {
+		int[] version_numbers = instance.getServerVersionParts();
+		if (version_numbers[0] < 0 || version_numbers[1] < 0) {
+			// Allow this plugin to run new API calls even if version can't be detected
+			// (A warning should already have been shown by getServerVersionParts):
+			return true;
+		}
+		return (version_numbers[0] >= majorVersion)
+			   && (version_numbers[1] >= minorVersion);
 	}
 }

--- a/src/me/mehboss/recipe/RecipeManager.java
+++ b/src/me/mehboss/recipe/RecipeManager.java
@@ -569,15 +569,13 @@ public class RecipeManager {
 	
 					Bukkit.getServer().addRecipe(S);
 				}
-			
-				api().addRecipe(item, ingredients);
-	
 				if (getConfig().getBoolean(item + ".Shapeless") == false)
 					Bukkit.getServer().addRecipe(R);
 	
 				if (debug())
 					debug("Added Recipe: " + item + " | With Amount: " + i.getAmount());
 			}
+			api().addRecipe(item, ingredients);  // Have to add *every* recipe, even with Converter, or "passedCheck" loop won't run on everything
 		}
 	}
 

--- a/src/me/mehboss/recipe/RecipeManager.java
+++ b/src/me/mehboss/recipe/RecipeManager.java
@@ -291,7 +291,7 @@ public class RecipeManager {
 			List<Material> findIngredients = new ArrayList<Material>();
 
 			List<String> loreList = new ArrayList<String>();
-			List<String> r = getConfig().getStringList(item + ".ItemCrafting");
+			List<String> gridRows = getConfig().getStringList(item + ".ItemCrafting");
 
 			String damage = getConfig().getString(item + ".Item-Damage");
 			int amount = getConfig().getInt(item + ".Amount");
@@ -341,10 +341,9 @@ public class RecipeManager {
 			m = handleLore(item, m);
 
 			i.setItemMeta(m);
-
-			String line1 = r.get(0);
-			String line2 = r.get(1);
-			String line3 = r.get(2);
+			String line1 = gridRows.get(0);
+			String line2 = gridRows.get(1);
+			String line3 = gridRows.get(2);
 
 			HashMap<String, Material> shape = new HashMap<String, Material>();
 			ArrayList<String> shapeletter = new ArrayList<String>();

--- a/src/me/mehboss/recipe/RecipeManager.java
+++ b/src/me/mehboss/recipe/RecipeManager.java
@@ -135,15 +135,9 @@ public class RecipeManager {
 		return i;
 	}
 
-	boolean server_below_1_14() {
-		String version = Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
-		return (version.contains("1_7") || version.contains("1_8") || version.contains("1_9") || version.contains("1_10")
-				|| version.contains("1_11") || version.contains("1_12") || version.contains("1_13"));
-	}
-
 	ItemMeta handleFlags(String item, ItemMeta m) {
 
-		if (server_below_1_14())
+		if (Main.serverVersionBelow(1, 14))
 			return m;
 
 		if (getConfig().isSet(item + ".Item-Flags")) {
@@ -207,9 +201,7 @@ public class RecipeManager {
 	}
 
 	ItemMeta handleCustomModelData(String item, ItemMeta m) {
-		String version = Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
-		if (version.contains("1_7") || version.contains("1_8") || version.contains("1_9") || version.contains("1_10")
-				|| version.contains("1_11") || version.contains("1_12") || version.contains("1_13"))
+		if (Main.serverVersionBelow(1, 14))
 			return m;
 
 		if (getConfig().isSet(item + ".Custom-Model-Data")
@@ -226,9 +218,7 @@ public class RecipeManager {
 	}
 
 	ItemMeta handleAttributes(String item, ItemMeta m) {
-		String version = Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
-		if (version.contains("1_7") || version.contains("1_8") || version.contains("1_9") || version.contains("1_10")
-				|| version.contains("1_11"))
+		if (Main.serverVersionBelow(1, 12))
 			return m;
 
 		if (getConfig().isSet(item + ".Attribute")) {
@@ -315,7 +305,7 @@ public class RecipeManager {
 					// always allowed
 				}
 				else if ("STONECUTTER".equals(converter)) {
-					if (server_below_1_14()) {
+					if (Main.serverVersionBelow(1, 14)) {
 						getLogger().log(Level.SEVERE, "Error loading recipe. Got " + converter
 								+" but your server version is below 1.14."
 								+" Expected FURNACE or no Converter (for regular crafting) in: " + recipeFile.getName());
@@ -393,10 +383,8 @@ public class RecipeManager {
 			itemNames().put(item, i);
 			configName().put(i, item);
 
-			String version = Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
 			NamespacedKey key = null;
-			if (!version.contains("1_7") && !version.contains("1_8") && !version.contains("1_9")
-					&& !version.contains("1_10") && !version.contains("1_11")) {
+			if (Main.serverVersionAtLeast(1, 12)) {
 				key = new NamespacedKey(Main.getInstance(), getConfig().getString(item + ".Identifier"));
 				R = new ShapedRecipe(key, i);
 				S = new ShapelessRecipe(key, i);
@@ -530,7 +518,8 @@ public class RecipeManager {
 			}
 			else if ("STONECUTTER".equals(converter)) {
 				org.bukkit.inventory.StonecuttingRecipe scRecipe = null;
-				// ^ Use full name to avoid import (importing StonecutterRecipe prevents backward compatibility < 1.14)
+				// ^ Use full name to avoid import (importing it would break all versions below
+				//   (1.14 since StonecuttingRecipe is only defined if server >= 1.14).
 				if (key != null) {
 					scRecipe = new org.bukkit.inventory.StonecuttingRecipe(key, i, findIngredients.get(0));
 				}

--- a/src/me/mehboss/recipe/RecipeManager.java
+++ b/src/me/mehboss/recipe/RecipeManager.java
@@ -275,7 +275,8 @@ public class RecipeManager {
 
 			if (!(recipeConfig.isConfigurationSection(item))) {
 				Main.getInstance().getLogger().log(Level.WARNING, "Could not find configuration section " + item
-						+ " in the recipe file: " + item + ".yml - (CaSeSeNsItIvE) - Skipping this recipe");
+						+ " in the recipe file that must match its filename: " + item
+						+ ".yml - (CaSeSeNsItIvE) - Skipping this recipe");
 				continue;
 			}
 


### PR DESCRIPTION
Its up to you if you want this, but it works fine. Let me know if anything doesn't seem right. Some testing in older versions should probably be done as explained.
- `Converter: FURNACE` in recipe file (under main section) makes a Furnace recipe.
- `Converter: STONECUTTER` in recipe file (under main section) makes a Stonecutter recipe.
  - Completely avoids the `StonecutterRecipe` class in versions below 1.14 for backward compatibility, by using fully qualified name instead of importing it.
  - [ ] test in version below 1.14 (plugin should show an error only if `Converter: STONECUTTER` is in a recipefile).

Other changes:
- Adds new `serverVersionBelow` and `serverVersionAtLeast` methods to make the code more clear and reliable
  - Old code (other than NBTEditor which is very specific about version parsing) also uses the methods now.
  - If version notation is *not* detected, `serverVersionAtLeast` returns true anyway, and `serverVersionBelow` returns false anyway (makes code try to run if version isn't detected, like the old code which only checked for "1_7" etc and disallowed those specific versions)
  - [ ] test in version below 1.7
- adds instructions about missing JAR references to a new file: references/requirements.md
- Rename `r` to `gridRows` for clarity.
- Improve the wording of an error which caused issue #4 (which was a question not unexpected behavior).

Tested with only Paper 1.20.1 and 1.20.4, but built jar against AdvancedEnchantments-8.7.4.jar, latest BungeeCord.jar, PlaceholderAPI-2.11.5.jar, spigot-api-1.19.2-R0.1-20221106.071812-39.jar from URLs noted in requirements.md. 