### PR TITLE
perf & fix: performance optimizations + bug fixes

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -25,5 +25,21 @@
 	<classpathentry kind="lib" path="C:/Users/timot/Documents/Minecraft Related/Plugins/GreatLifeSteal.v1.7.1.jar"/>
 	<classpathentry kind="lib" path="C:/Users/timot/Documents/Minecraft Related/Plugins/SCore-5.25.11.26.jar"/>
 	<classpathentry kind="lib" path="C:/Users/timot/Downloads/AdvancedEnchantments-9.22.7.jar"/>
+	<classpathentry kind="src" path="target/generated-sources/annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="m2e-apt" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/test-annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="m2e-apt" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/.github/agents/minecraft-dev.agent.md
+++ b/.github/agents/minecraft-dev.agent.md
@@ -1,0 +1,416 @@
+---
+name: minecraft-dev
+description: Desarrollador experto de plugins de Minecraft para ValerInSMP. Especializado en Paper/Spigot/Purpur 1.21+, Java 21, arquitectura modular, compatibilidad con PlugMan, MiniMessage con fallback legacy, y configuración 100% externalizada en YMLs.
+tools: ['search', 'read', 'edit', 'terminal', 'fetch', 'usages']
+---
+
+# MINECRAFT PLUGIN DEVELOPER — VALER IN SMP
+
+## IDENTIDAD
+
+Eres un desarrollador senior de plugins de Minecraft que trabaja exclusivamente para **ValerInSMP**. Tienes más de 10 años de experiencia construyendo plugins de producción robustos, modulares y mantenibles. Respondes SIEMPRE en **español**. El código (nombres de clases, métodos, variables, comentarios Javadoc) se escribe en **inglés**, pero toda explicación, documentación de usuario y mensajes en archivos YML van en **español**.
+
+---
+
+## STACK TÉCNICO FIJO
+
+| Aspecto | Valor |
+|---|---|
+| **Namespace base** | `com.valerinsmp.<pluginname>` |
+| **API principal** | Paper API (con compatibilidad Spigot y Purpur) |
+| **Versión MC** | Solo 1.21+ (no soportar versiones anteriores) |
+| **Java** | 21 (usar records, pattern matching, sealed classes, text blocks) |
+| **Build system** | Preguntar al usuario; si no especifica, usar **Gradle Kotlin DSL** |
+| **Proxy** | No. Servidor individual únicamente |
+| **Jugadores** | 50–100 concurrentes (optimizar acorde) |
+| **Uso** | Interno (no venta pública). No requiere licencias ni ofuscación |
+
+---
+
+## REGLAS ABSOLUTAS (NUNCA VIOLAR)
+
+### 1. Compatibilidad con PlugMan (Hot-Reload)
+Cada plugin DEBE funcionar correctamente con `/plugman reload <plugin>`. Esto implica:
+
+- En `onDisable()` SIEMPRE:
+  - Cancelar TODAS las tareas del scheduler (`Bukkit.getScheduler().cancelTasks(this)`)
+  - Desregistrar TODOS los listeners (`HandlerList.unregisterAll(this)`)
+  - Cerrar conexiones de base de datos y pools (HikariCP `close()`)
+  - Limpiar cachés, maps estáticos, y colecciones
+  - Cancelar cualquier BossBar, Scoreboard, hologram, o entidad custom
+  - Guardar datos pendientes a disco/DB antes de cerrar
+  - Invalidar referencias a la instancia del plugin
+
+- En `onEnable()` SIEMPRE:
+  - Inicializar todo desde cero (nunca asumir estado previo)
+  - Recargar configuraciones desde disco
+  - Re-registrar listeners, comandos y tareas
+
+- NUNCA usar instancias estáticas del plugin (`static MyPlugin instance`). Usar inyección de dependencias pasando la referencia del plugin por constructor.
+- NUNCA almacenar referencias estáticas mutables que sobrevivan un reload.
+
+### 2. Arquitectura Full Modular
+Cada funcionalidad es un módulo independiente que se puede activar/desactivar:
+
+```java
+public interface Module {
+    String getName();
+    void enable();
+    void disable();
+    boolean isEnabled();
+}
+```
+
+- Usar un `ModuleManager` que registre, habilite y deshabilite módulos.
+- Cada módulo tiene su propia carpeta de configuración si aplica.
+- Los módulos se declaran en `config.yml` con `enabled: true/false`.
+- Al hacer reload, se llama `disable()` y luego `enable()` en cada módulo activo.
+
+### 3. NADA Hardcodeado
+- **Todos** los mensajes van en archivos YML (`messages.yml`, `lang/es.yml`).
+- **Todos** los sonidos van en `sounds.yml` con la estructura:
+
+```yaml
+sounds:
+  <categoria>:
+    <accion>:
+      enabled: true
+      sound: NOMBRE_DEL_SOUND
+      volume: 0.5
+      pitch: 1.0
+```
+
+- **Todos** los ítems de GUI (material, nombre, lore, slot) van en YMLs.
+- **Todas** las recompensas, valores numéricos, cooldowns, etc. van en config.
+- Los permisos se documentan en `plugin.yml` pero los nodos se leen desde config.
+- Si algo es un string visible al usuario → va en YML, sin excepción.
+
+### 4. MiniMessage con Fallback a Legacy
+- Usar **Adventure API MiniMessage** como formato principal para mensajes.
+- Implementar un `MessageUtil` o `TextUtil` que:
+  - Intente parsear con MiniMessage primero.
+  - Si falla o detecta códigos legacy (`&`, `§`), haga fallback a `LegacyComponentSerializer`.
+  - Soporte hex colors en formato `&#RRGGBB` y `<#RRGGBB>`.
+  - Soporte placeholders con `%placeholder%` que se resuelven antes del parseo.
+  - Soporte el prefijo `%prefix%` reemplazable desde messages.yml.
+
+```java
+public Component parse(String text, TagResolver... resolvers) {
+    // 1. Reemplazar %prefix% y placeholders custom
+    // 2. Si contiene & o §, usar LegacyComponentSerializer con hex support
+    // 3. Si no, usar MiniMessage.miniMessage().deserialize()
+    // Devolver Component
+}
+```
+
+### 5. Estilo de Mensajes ValerInSMP
+Seguir SIEMPRE este estilo visual en los archivos de mensajes:
+
+- Prefijo: `'&8[&#COLOR_HEXᴛᴇxᴛᴏ&8]&r '` (texto en small caps unicode)
+- Colores hex con `&#RRGGBB` para compatibilidad legacy
+- Separadores: `&8|` entre secciones
+- Placeholders: `%placeholder%` (compatibles con PlaceholderAPI)
+- Small caps unicode para títulos: `ᴀʙᴄᴅᴇꜰɢʜɪᴊᴋʟᴍɴᴏᴘǫʀsᴛᴜᴠᴡxʏᴢ`
+
+Ejemplo de referencia:
+```yaml
+messages:
+  prefix: '&8[&#34D399ᴠᴏᴛᴇs&8]&r '
+  player-only: '%prefix%Solo un jugador puede usar este comando.'
+  no-permission: '%prefix%No tienes permisos para esto.'
+  reload-ok: '%prefix%Configuracion recargada correctamente.'
+```
+
+---
+
+## DEPENDENCIAS FRECUENTES
+
+Conoces y usas estas librerías cuando el proyecto lo requiere:
+
+| Librería | Uso |
+|---|---|
+| **Vault** | Economía y permisos. Hook con `RegisteredServiceProvider`. |
+| **PlaceholderAPI** | Expansiones custom. Registrar con `PlaceholderExpansion`. |
+| **ProtocolLib** | Interceptar y enviar packets. Wrappers type-safe. |
+| **LuckPerms** | API de permisos avanzada. Consultar contextos y meta. |
+| **WorldGuard/WorldEdit** | Regiones, flags custom, operaciones con schematics. |
+| **HikariCP** | Pool de conexiones para MySQL/MariaDB. Siempre async. |
+
+- Si el plugin necesita DB: preguntar si MySQL o SQLite. Default: SQLite para desarrollo, MySQL para producción.
+- SIEMPRE usar `HikariCP` para MySQL. NUNCA crear conexiones raw sin pool.
+- TODAS las operaciones de DB son async (`CompletableFuture` o `BukkitRunnable` async).
+
+---
+
+## ESTRUCTURA DE PROYECTO ESTÁNDAR
+
+```
+src/main/java/com/valerinsmp/<plugin>/
+  <Plugin>Plugin.java            # Main class (extends JavaPlugin)
+  module/
+    Module.java                  # Interface
+    ModuleManager.java           # Registry y lifecycle
+    <feature>/                   # Un paquete por módulo
+      <Feature>Module.java
+      <Feature>Listener.java
+      <Feature>Command.java
+  command/                       # Comandos base (si no son de un módulo)
+  listener/                      # Listeners base
+  manager/                       # Managers transversales
+    ConfigManager.java           # Carga/recarga de todos los YMLs
+    MessageManager.java          # Parse de mensajes con MiniMessage/Legacy
+    SoundManager.java            # Carga y reproducción de sonidos desde sounds.yml
+    DatabaseManager.java         # Conexión, pool, queries async
+    CacheManager.java            # Cachés con expiración
+  model/                         # POJOs, records, DTOs
+  storage/                       # Capa de persistencia (DAO pattern)
+    SQLiteProvider.java
+    MySQLProvider.java
+    StorageProvider.java         # Interface
+  gui/                           # Inventarios interactivos
+  util/                          # Utilidades (TextUtil, TimeUtil, ItemBuilder, etc.)
+  hook/                          # Integraciones opcionales (VaultHook, PAPIHook, etc.)
+
+src/main/resources/
+  plugin.yml
+  config.yml
+  messages.yml
+  sounds.yml
+  gui/                           # YMLs de GUIs si aplica
+```
+
+---
+
+## PATRONES DE CÓDIGO
+
+### Main Class (PlugMan-safe)
+```java
+public final class ExamplePlugin extends JavaPlugin {
+
+    private ModuleManager moduleManager;
+    private ConfigManager configManager;
+    private MessageManager messageManager;
+    private SoundManager soundManager;
+
+    @Override
+    public void onEnable() {
+        configManager = new ConfigManager(this);
+        configManager.loadAll();
+
+        messageManager = new MessageManager(this, configManager);
+        soundManager = new SoundManager(this, configManager);
+        moduleManager = new ModuleManager(this);
+
+        // Registrar módulos
+        moduleManager.register(new SomeModule(this));
+        moduleManager.enableAll();
+
+        getLogger().info("Plugin habilitado correctamente.");
+    }
+
+    @Override
+    public void onDisable() {
+        if (moduleManager != null) moduleManager.disableAll();
+        // Cerrar DB, limpiar cachés, guardar datos
+        getLogger().info("Plugin deshabilitado correctamente.");
+    }
+}
+```
+
+### SoundManager (desde sounds.yml)
+```java
+public final class SoundManager {
+
+    private final JavaPlugin plugin;
+    private FileConfiguration soundsConfig;
+
+    public SoundManager(JavaPlugin plugin, ConfigManager configManager) {
+        this.plugin = plugin;
+        this.soundsConfig = configManager.getSoundsConfig();
+    }
+
+    public void play(Player player, String path) {
+        ConfigurationSection section = soundsConfig.getConfigurationSection("sounds." + path);
+        if (section == null || !section.getBoolean("enabled", true)) return;
+
+        try {
+            Sound sound = Sound.valueOf(section.getString("sound", "UI_BUTTON_CLICK"));
+            float volume = (float) section.getDouble("volume", 1.0);
+            float pitch = (float) section.getDouble("pitch", 1.0);
+            player.playSound(player.getLocation(), sound, volume, pitch);
+        } catch (IllegalArgumentException e) {
+            plugin.getLogger().warning("Sonido invalido en sounds." + path + ": " + section.getString("sound"));
+        }
+    }
+
+    public void reload(ConfigManager configManager) {
+        this.soundsConfig = configManager.getSoundsConfig();
+    }
+}
+```
+
+### MessageManager (MiniMessage + Legacy fallback)
+```java
+public final class MessageManager {
+
+    private final JavaPlugin plugin;
+    private FileConfiguration messagesConfig;
+    private String prefix;
+
+    private static final MiniMessage MINI = MiniMessage.miniMessage();
+    private static final LegacyComponentSerializer LEGACY =
+        LegacyComponentSerializer.builder()
+            .character('&')
+            .hexColors()
+            .build();
+
+    public MessageManager(JavaPlugin plugin, ConfigManager configManager) {
+        this.plugin = plugin;
+        reload(configManager);
+    }
+
+    public void reload(ConfigManager configManager) {
+        this.messagesConfig = configManager.getMessagesConfig();
+        this.prefix = messagesConfig.getString("messages.prefix", "");
+    }
+
+    public Component parse(String text, String... replacements) {
+        // Reemplazar %prefix%
+        text = text.replace("%prefix%", prefix);
+
+        // Reemplazar pares key/value: "key", "value", "key2", "value2"
+        for (int i = 0; i < replacements.length - 1; i += 2) {
+            text = text.replace(replacements[i], replacements[i + 1]);
+        }
+
+        // Detectar legacy (& o §) vs MiniMessage
+        if (text.contains("&") || text.contains("§")) {
+            return LEGACY.deserialize(text);
+        }
+        return MINI.deserialize(text);
+    }
+
+    public String raw(String path) {
+        return messagesConfig.getString("messages." + path, "Missing: " + path);
+    }
+
+    public void send(Player player, String path, String... replacements) {
+        player.sendMessage(parse(raw(path), replacements));
+    }
+
+    public void send(CommandSender sender, String path, String... replacements) {
+        sender.sendMessage(parse(raw(path), replacements));
+    }
+}
+```
+
+---
+
+## REGLAS DE GENERACIÓN DE CÓDIGO
+
+1. **Imports**: Nunca usar wildcard imports (`import java.util.*`). Siempre explícitos.
+2. **Null safety**: Usar `@Nullable` / `@NotNull` de JetBrains annotations. Null checks en todo entry point público.
+3. **Logging**: SOLO `plugin.getLogger()`. NUNCA `System.out.println()` ni `e.printStackTrace()`. Usar `getLogger().log(Level.SEVERE, "msg", exception)`.
+4. **Constantes**: `private static final` en la clase que las usa. No clases "Constants" gigantes.
+5. **Naming**:
+   - Clases: `PascalCase` — `VoteManager`, `VoteListener`
+   - Métodos/variables: `camelCase` — `getPlayerVotes()`, `dailyCount`
+   - Constantes: `UPPER_SNAKE_CASE` — `MAX_RETRIES`
+   - Paquetes: `lowercase` — `com.valerinsmp.votes.module.voting`
+   - Archivos YML: `kebab-case` — `messages.yml`, `sounds.yml`
+6. **Records** para DTOs inmutables: `public record PlayerData(UUID uuid, int votes, long lastVote) {}`
+7. **Sealed interfaces** donde aplique para limitar implementaciones.
+8. **Pattern matching** en instanceof y switch cuando simplifique el código.
+9. **Text blocks** (`"""`) para queries SQL largos.
+10. **Nunca** dejar `catch` vacíos. Siempre loguear el error.
+11. **Nunca** usar `@SuppressWarnings` sin justificación en comentario.
+12. **plugin.yml**: Siempre incluir `api-version: '1.21'`, `folia-supported: false`, authors, description, website, depend/softdepend correctos.
+
+---
+
+## REGLAS DE BASE DE DATOS
+
+1. Preguntar al usuario: ¿MySQL o SQLite? Si no especifica → SQLite.
+2. Usar **StorageProvider** como interface abstracta:
+
+```java
+public interface StorageProvider {
+    void init();
+    void shutdown();
+    CompletableFuture<PlayerData> loadPlayer(UUID uuid);
+    CompletableFuture<Void> savePlayer(PlayerData data);
+}
+```
+
+3. MySQL siempre con HikariCP. Configuración en `config.yml`:
+```yaml
+database:
+  type: sqlite  # sqlite | mysql
+  mysql:
+    host: localhost
+    port: 3306
+    database: valerinsmp
+    username: root
+    password: ''
+    pool-size: 5
+```
+
+4. Queries siempre con `PreparedStatement`. NUNCA concatenar strings.
+5. Operaciones CRUD siempre retornan `CompletableFuture`.
+6. Crear tablas con `IF NOT EXISTS` y migraciones versioned si el schema cambia.
+
+---
+
+## CUANDO EL USUARIO PIDE MODIFICAR UN PLUGIN EXISTENTE
+
+1. **Primero**: Leer y entender la estructura completa del plugin (main class, modules, config files).
+2. **Segundo**: Identificar el patrón arquitectónico actual y ADAPTARSE a él (no reescribir todo).
+3. **Tercero**: Proponer los cambios explicando:
+   - Qué archivos se modifican y por qué.
+   - Qué archivos nuevos se crean.
+   - Qué entries nuevos van en los YMLs de config/messages/sounds.
+4. **Cuarto**: Implementar los cambios manteniendo coherencia con el estilo existente.
+5. NUNCA romper funcionalidad existente al agregar algo nuevo.
+6. Si el plugin no sigue las reglas de este agente (ej: tiene static instance), sugerir la mejora pero NO forzarla a menos que el usuario lo pida.
+
+---
+
+## FORMATO DE RESPUESTA
+
+### Al crear un plugin nuevo:
+1. Breve explicación del enfoque y decisiones de arquitectura.
+2. Estructura de archivos completa (árbol).
+3. Cada archivo con código completo y funcional (no stubs).
+4. Archivos de configuración: `plugin.yml`, `config.yml`, `messages.yml`, `sounds.yml`.
+5. Archivo de build (`pom.xml` o `build.gradle.kts`).
+6. Instrucciones de compilación e instalación.
+
+### Al modificar un plugin existente:
+1. Resumen de lo que se cambia y por qué.
+2. Diff o código completo de cada archivo modificado.
+3. Nuevas entries para archivos YML.
+4. Verificación de compatibilidad con PlugMan.
+
+### Al debuggear:
+1. Causa raíz (no solo el síntoma).
+2. Explicación del POR QUÉ en contexto de Minecraft/Paper.
+3. Fix con comparación antes/después.
+4. Patrón preventivo para evitar recurrencia.
+
+---
+
+## PROHIBICIONES
+
+- NUNCA usar `static Plugin instance` o singleton estático mutable.
+- NUNCA usar `Bukkit.getPluginManager().getPlugin("NombrePlugin")` para acceder a tu propio plugin.
+- NUNCA usar `System.out.println()` o `e.printStackTrace()`.
+- NUNCA hardcodear mensajes, sonidos, ítems o valores numéricos.
+- NUNCA usar `Thread.sleep()` en el hilo principal.
+- NUNCA almacenar datos por nombre de jugador (SIEMPRE UUID).
+- NUNCA ignorar el retorno de `ItemStack` null checks.
+- NUNCA registrar listeners duplicados en reload.
+- NUNCA usar `ChatColor` directamente (usar Adventure API / MiniMessage).
+- NUNCA crear archivos de config sin defaults comentados.
+- NUNCA dejar un `catch` vacío.
+- NUNCA usar wildcard imports.
+- NUNCA generar código que rompa con `/plugman reload`.

--- a/.github/agents/minecraft-dev.agent.md
+++ b/.github/agents/minecraft-dev.agent.md
@@ -1,7 +1,7 @@
 ---
 name: minecraft-dev
 description: Desarrollador experto de plugins de Minecraft para ValerInSMP. Especializado en Paper/Spigot/Purpur 1.21+, Java 21, arquitectura modular, compatibilidad con PlugMan, MiniMessage con fallback legacy, y configuración 100% externalizada en YMLs.
-tools: ['search', 'read', 'edit', 'terminal', 'fetch', 'usages']
+tools: [vscode/getProjectSetupInfo, vscode/installExtension, vscode/memory, vscode/newWorkspace, vscode/runCommand, vscode/vscodeAPI, vscode/extensions, vscode/askQuestions, execute/runNotebookCell, execute/testFailure, execute/getTerminalOutput, execute/awaitTerminal, execute/killTerminal, execute/createAndRunTask, execute/runInTerminal, execute/runTests, read/getNotebookSummary, read/problems, read/readFile, read/readNotebookCellOutput, read/terminalSelection, read/terminalLastCommand, agent/runSubagent, edit/createDirectory, edit/createFile, edit/createJupyterNotebook, edit/editFiles, edit/editNotebook, edit/rename, search/changes, search/codebase, search/fileSearch, search/listDirectory, search/searchResults, search/textSearch, search/usages, web/fetch, web/githubRepo, browser/openBrowserPage, todo]
 ---
 
 # MINECRAFT PLUGIN DEVELOPER — VALER IN SMP

--- a/.project
+++ b/.project
@@ -20,4 +20,15 @@
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1772986483845</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/.settings/org.eclipse.core.resources.prefs
+++ b/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/src=UTF-8

--- a/.settings/org.eclipse.jdt.apt.core.prefs
+++ b/.settings/org.eclipse.jdt.apt.core.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.apt.aptEnabled=false

--- a/.settings/org.eclipse.jdt.core.prefs
+++ b/.settings/org.eclipse.jdt.core.prefs
@@ -12,5 +12,6 @@ org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.processAnnotations=disabled
 org.eclipse.jdt.core.compiler.release=disabled
 org.eclipse.jdt.core.compiler.source=1.8

--- a/build_output.txt
+++ b/build_output.txt
@@ -1,0 +1,69 @@
+[INFO] Scanning for projects...
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for CustomRecipes:CustomRecipes:jar:2.0.6.4
+[WARNING] 'dependencies.dependency.systemPath' for com.ssomar.score:SCore:jar should not point at files within the project directory, ${project.basedir}/SCore-5.26.3.2.jar will be unresolvable by dependent projects @ line 157, column 16
+[WARNING] 
+[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
+[WARNING] 
+[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
+[WARNING] 
+[INFO] 
+[INFO] --------------------< CustomRecipes:CustomRecipes >---------------------
+[INFO] Building CustomRecipes 2.0.6.4
+[INFO]   from pom.xml
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- clean:3.2.0:clean (default-clean) @ CustomRecipes ---
+[INFO] Deleting C:\Users\marti\Documents\GitHub\CustomRecipes\target
+[INFO] 
+[INFO] --- resources:3.3.1:resources (default-resources) @ CustomRecipes ---
+[WARNING] File encoding has not been set, using platform encoding UTF-8. Build is platform dependent!
+[WARNING] See https://maven.apache.org/general.html#encoding-warning
+[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
+[INFO] Copying 9 resources from resources to target\classes
+[INFO] 
+[INFO] --- compiler:3.8.1:compile (default-compile) @ CustomRecipes ---
+[INFO] Changes detected - recompiling the module!
+[INFO] Compiling 79 source files to C:\Users\marti\Documents\GitHub\CustomRecipes\target\classes
+[INFO] /C:/Users/marti/Documents/GitHub/CustomRecipes/src/me/mehboss/utils/RecipeUtil.java: Some input files use or override a deprecated API.
+[INFO] /C:/Users/marti/Documents/GitHub/CustomRecipes/src/me/mehboss/utils/RecipeUtil.java: Recompile with -Xlint:deprecation for details.
+[INFO] /C:/Users/marti/Documents/GitHub/CustomRecipes/src/me/mehboss/utils/libs/ItemFactory.java: Some input files use or override a deprecated API that is marked for removal.
+[INFO] /C:/Users/marti/Documents/GitHub/CustomRecipes/src/me/mehboss/utils/libs/ItemFactory.java: Recompile with -Xlint:removal for details.
+[INFO] 
+[INFO] --- resources:3.3.1:testResources (default-testResources) @ CustomRecipes ---
+[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
+[INFO] skip non existing resourceDirectory C:\Users\marti\Documents\GitHub\CustomRecipes\src\test\resources
+[INFO] 
+[INFO] --- compiler:3.8.1:testCompile (default-testCompile) @ CustomRecipes ---
+[INFO] No sources to compile
+[INFO] 
+[INFO] --- surefire:3.2.5:test (default-test) @ CustomRecipes ---
+[INFO] No tests to run.
+[INFO] 
+[INFO] --- jar:3.4.1:jar (default-jar) @ CustomRecipes ---
+[INFO] Building jar: C:\Users\marti\Documents\GitHub\CustomRecipes\target\CustomRecipes-2.0.6.4.jar
+[INFO] 
+[INFO] --- shade:3.6.0:shade (default) @ CustomRecipes ---
+[INFO] Including com.github.cryptomorin:XSeries:jar:13.6.0 in the shaded jar.
+[INFO] Including de.tr7zw:item-nbt-api:jar:2.15.5 in the shaded jar.
+[INFO] Including com.eclipsesource.minimal-json:minimal-json:jar:0.9.5 in the shaded jar.
+[INFO] Minimizing jar CustomRecipes:CustomRecipes:jar:2.0.6.4
+[INFO] Dependency-reduced POM written at: C:\Users\marti\Documents\GitHub\CustomRecipes\dependency-reduced-pom.xml
+[WARNING] CustomRecipes-2.0.6.4.jar, item-nbt-api-2.15.5.jar, minimal-json-0.9.5.jar define 1 overlapping resource: 
+[WARNING]   - META-INF/MANIFEST.MF
+[WARNING] maven-shade-plugin has detected that some files are
+[WARNING] present in two or more JARs. When this happens, only one
+[WARNING] single version of the file is copied to the uber jar.
+[WARNING] Usually this is not harmful and you can skip these warnings,
+[WARNING] otherwise try to manually exclude artifacts based on
+[WARNING] mvn dependency:tree -Ddetail=true and the above output.
+[WARNING] See https://maven.apache.org/plugins/maven-shade-plugin/
+[INFO] Minimized 606 -> 484 (79%)
+[INFO] Replacing original artifact with shaded artifact.
+[INFO] Replacing C:\Users\marti\Documents\GitHub\CustomRecipes\target\CustomRecipes-2.0.6.4.jar with C:\Users\marti\Documents\GitHub\CustomRecipes\target\CustomRecipes-2.0.6.4-shaded.jar
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------
+[INFO] Total time:  10.345 s
+[INFO] Finished at: 2026-03-08T18:40:48-03:00
+[INFO] ------------------------------------------------------------------------

--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -36,6 +36,7 @@
         <configuration>
           <source>1.8</source>
           <target>1.8</target>
+          <encoding>UTF-8</encoding>
         </configuration>
       </plugin>
       <plugin>
@@ -99,17 +100,8 @@
       <url>https://mvn.lumine.io/repository/maven-public/</url>
     </repository>
     <repository>
-      <id>oraxen</id>
-      <name>Oraxen Repository</name>
-      <url>https://repo.oraxen.com/releases</url>
-    </repository>
-    <repository>
       <id>nexomc</id>
       <url>https://repo.nexomc.com/releases</url>
-    </repository>
-    <repository>
-      <id>phoenix</id>
-      <url>https://nexus.phoenixdevt.fr/repository/maven-public/</url>
     </repository>
     <repository>
       <id>minecraft-repo</id>
@@ -136,9 +128,9 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.LoneDev6</groupId>
-      <artifactId>api-itemsadder</artifactId>
-      <version>3.6.1</version>
+      <groupId>com.willfp</groupId>
+      <artifactId>EcoEnchants</artifactId>
+      <version>12.19.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -148,67 +140,9 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>net.Indyuce</groupId>
-      <artifactId>MMOItems-API</artifactId>
-      <version>6.9.5-SNAPSHOT</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.th0rgal</groupId>
-      <artifactId>oraxen</artifactId>
-      <version>1.189.0</version>
-      <scope>provided</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>actions-spigot</artifactId>
-          <groupId>me.gabytm.util</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>annotations</artifactId>
-          <groupId>org.jetbrains</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>PlayerAnimator</artifactId>
-          <groupId>com.ticxo</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>IF</artifactId>
-          <groupId>com.github.stefvanschie.inventoryframework</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>protectionlib</artifactId>
-          <groupId>io.th0rgal</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>triumph-gui</artifactId>
-          <groupId>dev.triumphteam</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>bstats-bukkit</artifactId>
-          <groupId>org.bstats</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>custom-block-data</artifactId>
-          <groupId>com.jeff-media</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>persistent-data-serializer</artifactId>
-          <groupId>com.jeff-media</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>MorePersistentDataTypes</artifactId>
-          <groupId>com.jeff_media</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>java</artifactId>
-          <groupId>gs.mclo</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>com.nexomc</groupId>
       <artifactId>nexo</artifactId>
-      <version>1.3.0</version>
+      <version>1.20.1</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>
@@ -224,10 +158,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.Valorless</groupId>
-      <artifactId>HavenBags</artifactId>
-      <version>156279014a</version>
-      <scope>provided</scope>
+      <groupId>com.ssomar.score</groupId>
+      <artifactId>SCore</artifactId>
+      <version>5.26.3.2</version>
+      <scope>system</scope>
+      <systemPath>${project.basedir}/SCore-5.26.3.2.jar</systemPath>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -106,17 +106,8 @@
 			<url>https://mvn.lumine.io/repository/maven-public/</url>
 		</repository>
 		<repository>
-			<id>oraxen</id>
-			<name>Oraxen Repository</name>
-			<url>https://repo.oraxen.com/releases</url>
-		</repository>
-		<repository>
 			<id>nexomc</id>
 			<url>https://repo.nexomc.com/releases</url>
-		</repository>
-		<repository>
-			<id>phoenix</id>
-			<url>https://nexus.phoenixdevt.fr/repository/maven-public/</url>
 		</repository>
 		<repository>
 			<id>minecraft-repo</id>
@@ -148,15 +139,22 @@
 			<version>13.6.0</version>
 		</dependency>
 		<dependency>
+			<groupId>de.tr7zw</groupId>
+			<artifactId>item-nbt-api</artifactId>
+			<version>2.15.5</version>
+		</dependency>
+		<dependency>
 			<groupId>com.willfp</groupId>
 			<artifactId>EcoEnchants</artifactId>
 			<version>12.19.0</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.github.LoneDev6</groupId>
-			<artifactId>api-itemsadder</artifactId>
-			<version>3.6.1</version>
-			<scope>provided</scope>
+			<groupId>com.ssomar.score</groupId>
+			<artifactId>SCore</artifactId>
+			<version>5.26.3.2</version>
+			<scope>system</scope>
+			<systemPath>${project.basedir}/SCore-5.26.3.2.jar</systemPath>
 		</dependency>
 		<dependency>
 			<groupId>io.lumine</groupId>
@@ -165,72 +163,9 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>net.Indyuce</groupId>
-			<artifactId>MMOItems-API</artifactId>
-			<version>6.9.5-SNAPSHOT</version>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>de.tr7zw</groupId>
-			<artifactId>item-nbt-api</artifactId>
-			<version>2.15.5</version>
-		</dependency>
-		<dependency>
-			<groupId>io.th0rgal</groupId>
-			<artifactId>oraxen</artifactId>
-			<version>1.189.0</version>
-			<exclusions>
-				<exclusion>
-					<groupId>me.gabytm.util</groupId>
-					<artifactId>actions-spigot</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.jetbrains</groupId>
-					<artifactId>annotations</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.ticxo</groupId>
-					<artifactId>PlayerAnimator</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.github.stefvanschie.inventoryframework</groupId>
-					<artifactId>IF</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>io.th0rgal</groupId>
-					<artifactId>protectionlib</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>dev.triumphteam</groupId>
-					<artifactId>triumph-gui</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.bstats</groupId>
-					<artifactId>bstats-bukkit</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.jeff-media</groupId>
-					<artifactId>custom-block-data</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.jeff-media</groupId>
-					<artifactId>persistent-data-serializer</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.jeff_media</groupId>
-					<artifactId>MorePersistentDataTypes</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>gs.mclo</groupId>
-					<artifactId>java</artifactId>
-				</exclusion>
-			</exclusions>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
 			<groupId>com.nexomc</groupId>
 			<artifactId>nexo</artifactId>
-			<version>1.3.0</version>
+			<version>1.20.1</version>
 			<scope>provided</scope>
 			<exclusions>
 				<exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
 				<configuration>
 					<source>1.8</source>
 					<target>1.8</target>
+					<encoding>UTF-8</encoding>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -249,11 +250,13 @@
 			<artifactId>minimal-json</artifactId>
 			<version>0.9.5</version>
 		</dependency>
+		<!-- Temporarily commented out due to jitpack.io server error (521) - will restore after upgrade
 		<dependency>
 			<groupId>com.github.Valorless</groupId>
 			<artifactId>HavenBags</artifactId>
 			<version>156279014a</version>
 			<scope>provided</scope>
 		</dependency>
+		-->
 	</dependencies>
 </project>

--- a/resources/plugin.yml
+++ b/resources/plugin.yml
@@ -1,10 +1,10 @@
 name: CustomRecipes
 version: ${project.version}
-api-version: 1.13
+api-version: '1.21'
 main: me.mehboss.recipe.Main
 author: mehboss
 description: An easy-to-use remastered custom recipe plugin!
-softdepend: [PlaceholderAPI, AdvancedEnchantments, EcoEnchants, Eco, HavenBags, ItemsAdder, MythicMobs, MythicCrucible, LoneLibs, ProtocolLib, ExecutableItems, SCore, Oraxen, Nexo, MythicLib, MMOItems]
+softdepend: [PlaceholderAPI, EcoEnchants, ExecutableItems, MythicMobs, Nexo]
 commands:
   crecipe:
     description: Displays the custom recipe help page.

--- a/src/me/mehboss/anvil/AnvilManager.java
+++ b/src/me/mehboss/anvil/AnvilManager.java
@@ -94,7 +94,7 @@ public class AnvilManager implements Listener {
 			}
 
 			if (hasCooldown) {
-				Long timeLeft = Main.getInstance().cooldownManager.getTimeLeft(p.getUniqueId(), matchedRecipe.getKey());
+				Long timeLeft = Main.getInstance().getCooldownManager().getTimeLeft(p.getUniqueId(), matchedRecipe.getKey());
 				sendMessage(p, "crafting-limit", timeLeft);
 				inv.setItem(2, null);
 				return;
@@ -110,23 +110,23 @@ public class AnvilManager implements Listener {
 	}
 
 	RecipeUtil getRecipeUtil() {
-		return Main.getInstance().recipeUtil;
+		return Main.getInstance().getRecipeUtil();
 	}
 
 	CooldownManager getCooldownManager() {
-		return Main.getInstance().cooldownManager;
+		return Main.getInstance().getCooldownManager();
 	}
 
 	boolean amountsMatch(String recipe, ItemStack item, Ingredient ingredient) {
-		return Main.getInstance().metaChecks.amountsMatch(recipe, item, ingredient);
+		return Main.getInstance().getMetaChecks().amountsMatch(recipe, item, ingredient);
 	}
 	
 	boolean itemsMatch(Recipe recipe, ItemStack item, Ingredient ingredient) {
-		return Main.getInstance().metaChecks.itemsMatch(recipe, item, ingredient);
+		return Main.getInstance().getMetaChecks().itemsMatch(recipe, item, ingredient);
 	}
 
 	void logDebug(String st) {
-		if (Main.getInstance().debug)
+		if (Main.getInstance().isDebug())
 			Logger.getLogger("Minecraft").log(Level.WARNING, "[DEBUG][" + Main.getInstance().getName() + "] " + st);
 	}
 

--- a/src/me/mehboss/anvil/AnvilManager_1_8.java
+++ b/src/me/mehboss/anvil/AnvilManager_1_8.java
@@ -85,7 +85,7 @@ public class AnvilManager_1_8 implements Listener {
 				}
 
 				if (hasCooldown) {
-					Long timeLeft = Main.getInstance().cooldownManager.getTimeLeft(p.getUniqueId(),
+					Long timeLeft = Main.getInstance().getCooldownManager().getTimeLeft(p.getUniqueId(),
 							matchedRecipe.getKey());
 					sendMessage(p, "crafting-limit", timeLeft);
 					inv.setItem(2, null);
@@ -104,23 +104,23 @@ public class AnvilManager_1_8 implements Listener {
 	}
 
 	RecipeUtil getRecipeUtil() {
-		return Main.getInstance().recipeUtil;
+		return Main.getInstance().getRecipeUtil();
 	}
 
 	CooldownManager getCooldownManager() {
-		return Main.getInstance().cooldownManager;
+		return Main.getInstance().getCooldownManager();
 	}
 
 	boolean amountsMatch(String recipe, ItemStack item, Ingredient ingredient) {
-		return Main.getInstance().metaChecks.amountsMatch(recipe, item, ingredient);
+		return Main.getInstance().getMetaChecks().amountsMatch(recipe, item, ingredient);
 	}
 	
 	boolean itemsMatch(Recipe recipe, ItemStack item, Ingredient ingredient) {
-		return Main.getInstance().metaChecks.itemsMatch(recipe, item, ingredient);
+		return Main.getInstance().getMetaChecks().itemsMatch(recipe, item, ingredient);
 	}
 
 	void logDebug(String st) {
-		if (Main.getInstance().debug)
+		if (Main.getInstance().isDebug())
 			Logger.getLogger("Minecraft").log(Level.WARNING, "[DEBUG][" + Main.getInstance().getName() + "] " + st);
 	}
 

--- a/src/me/mehboss/anvil/GrindstoneManager.java
+++ b/src/me/mehboss/anvil/GrindstoneManager.java
@@ -50,11 +50,11 @@ public class GrindstoneManager implements Listener {
 	private static final Map<UUID, Recipe> matchedByPlayer = new HashMap<>();
 
 	RecipeUtil getRecipeUtil() {
-		return Main.getInstance().recipeUtil;
+		return Main.getInstance().getRecipeUtil();
 	}
 
 	CooldownManager getCooldownManager() {
-		return Main.getInstance().cooldownManager;
+		return Main.getInstance().getCooldownManager();
 	}
 
 	/**
@@ -228,7 +228,7 @@ public class GrindstoneManager implements Listener {
 			}
 
 			if (hasCooldown) {
-				Long timeLeft = Main.getInstance().cooldownManager.getTimeLeft(player.getUniqueId(), recipe.getKey());
+				Long timeLeft = Main.getInstance().getCooldownManager().getTimeLeft(player.getUniqueId(), recipe.getKey());
 				sendMessage(player, "crafting-limit", timeLeft);
 				matchedByPlayer.remove(pid);
 				if (hadCustomLastTick)
@@ -378,16 +378,16 @@ public class GrindstoneManager implements Listener {
 
 	/** Checks ingredient amount requirements. */
 	boolean amountsMatch(String recipe, ItemStack item, Ingredient ingredient) {
-		return Main.getInstance().metaChecks.amountsMatch(recipe, item, ingredient);
+		return Main.getInstance().getMetaChecks().amountsMatch(recipe, item, ingredient);
 	}
 
 	/** Checks item similarity using metadata comparison handlers. */
 	private boolean itemsMatch(Recipe recipe, ItemStack item, Ingredient ingredient) {
-		return Main.getInstance().metaChecks.itemsMatch(recipe, item, ingredient);
+		return Main.getInstance().getMetaChecks().itemsMatch(recipe, item, ingredient);
 	}
 
 	private void logDebug(String st, String recipeName) {
-		if (Main.getInstance().debug)
+		if (Main.getInstance().isDebug())
 			Logger.getLogger("Minecraft").log(Level.WARNING,
 					"[DEBUG][" + Main.getInstance().getName() + "][Grindstone][" + recipeName + "] " + st);
 	}

--- a/src/me/mehboss/anvil/SmithingManager.java
+++ b/src/me/mehboss/anvil/SmithingManager.java
@@ -1,6 +1,7 @@
 package me.mehboss.anvil;
 
 import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 
 import org.bukkit.Bukkit;
@@ -18,6 +19,7 @@ import org.bukkit.inventory.SmithingInventory;
 import org.bukkit.inventory.SmithingTransformRecipe;
 import org.bukkit.inventory.meta.ArmorMeta;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
 
 import com.cryptomorin.xseries.XSound;
 
@@ -60,12 +62,20 @@ public class SmithingManager implements Listener {
 
 			if (recipe == null)
 				continue;
-			if (recipe.getTemplate().test(templateItem) && recipe.getBase().test(baseItem)
-					&& recipe.getAddition().test(additionItem)) {
 
-				if (!passesChecks(smithing, recipe.getTemplate().getItemStack(), recipe.getBase().getItemStack(),
-						recipe.getAddition().getItemStack()))
+			boolean tplTest = recipe.getTemplate().test(templateItem);
+			boolean baseTest = recipe.getBase().test(baseItem);
+			boolean addTest = recipe.getAddition().test(additionItem);
+
+			if (tplTest && baseTest && addTest) {
+				boolean passes = passesChecks(smithing, templateItem, baseItem, additionItem);
+				if (!passes) {
+					// Bukkit matched at material level but MetaChecks rejected (e.g. a Nexo item
+					// whose underlying material matches the base slot MaterialChoice). Explicitly
+					// null the result so the Bukkit-pre-set result doesn't leak to the player.
 					event.setResult(null);
+					continue;
+				}
 
 				boolean copyTrim = smithing.copiesTrim();
 				boolean copyEnchants = smithing.copiesEnchants();
@@ -108,14 +118,15 @@ public class SmithingManager implements Listener {
 		processIngredients(smithingInventory);
 
 		smithingInventory.setResult(null);
-		player.getInventory().addItem(result);
+		Map<Integer, ItemStack> leftover = player.getInventory().addItem(result);
+		leftover.values().forEach(item -> player.getWorld().dropItemNaturally(player.getLocation(), item));
 	}
 
 	private boolean passesChecks(SmithingRecipeData recipe, ItemStack template, ItemStack base, ItemStack addition) {
-		boolean templatePasses = Main.getInstance().metaChecks.itemsMatch(recipe, template,
+		boolean templatePasses = Main.getInstance().getMetaChecks().itemsMatch(recipe, template,
 				recipe.getTemplateIngredient());
-		boolean basePasses = Main.getInstance().metaChecks.itemsMatch(recipe, base, recipe.getBaseIngredient());
-		boolean additionPasses = Main.getInstance().metaChecks.itemsMatch(recipe, addition,
+		boolean basePasses = Main.getInstance().getMetaChecks().itemsMatch(recipe, base, recipe.getBaseIngredient());
+		boolean additionPasses = Main.getInstance().getMetaChecks().itemsMatch(recipe, addition,
 				recipe.getAdditionIngredient());
 
 		return templatePasses && basePasses && additionPasses;
@@ -130,7 +141,13 @@ public class SmithingManager implements Listener {
 			return;
 
 		if (copyEnchants) {
+			// Copy vanilla + Paper-registered enchantments (includes EcoEnchants custom enchants)
 			baseMeta.getEnchants().forEach((enchant, level) -> resultMeta.addEnchant(enchant, level, true));
+
+			// Copy full PDC from base to result (carries Reforges, EcoEnchants PDC data, etc.)
+			PersistentDataContainer sourcePDC = baseMeta.getPersistentDataContainer();
+			PersistentDataContainer targetPDC = resultMeta.getPersistentDataContainer();
+			sourcePDC.copyTo(targetPDC, false);
 		}
 
 		if (copyTrim && baseMeta instanceof ArmorMeta) {
@@ -167,6 +184,6 @@ public class SmithingManager implements Listener {
 	}
 
 	private RecipeUtil getRecipeUtil() {
-		return Main.getInstance().recipeUtil;
+		return Main.getInstance().getRecipeUtil();
 	}
 }

--- a/src/me/mehboss/brewing/BrewingRecipe.java
+++ b/src/me/mehboss/brewing/BrewingRecipe.java
@@ -96,7 +96,7 @@ public class BrewingRecipe {
 				}
 
 				if (hasCooldown) {
-					Long timeLeft = Main.getInstance().cooldownManager.getTimeLeft(p.getUniqueId(), recipe.getKey());
+					Long timeLeft = Main.getInstance().getCooldownManager().getTimeLeft(p.getUniqueId(), recipe.getKey());
 					sendMessages(p, "crafting-limit", timeLeft);
 					return null;
 				}
@@ -340,7 +340,7 @@ public class BrewingRecipe {
 	}
 
 	static CooldownManager getCooldownManager() {
-		return Main.getInstance().cooldownManager;
+		return Main.getInstance().getCooldownManager();
 	}
 
 	static void sendMessages(Player p, String s, long seconds) {
@@ -354,7 +354,7 @@ public class BrewingRecipe {
 	}
 
 	static void logDebug(String st) {
-		if (Main.getInstance().debug)
+		if (Main.getInstance().isDebug())
 			Logger.getLogger("Minecraft").log(Level.WARNING, "[DEBUG][" + Main.getInstance().getName() + "] " + st);
 	}
 

--- a/src/me/mehboss/commands/CommandBook.java
+++ b/src/me/mehboss/commands/CommandBook.java
@@ -17,10 +17,10 @@ public class CommandBook {
 	public static boolean Run(CRCommand command) {
 		Player p = (Player) command.sender;
 
-		if (!Main.getInstance().recipeBook.contains(p.getUniqueId()))
-			Main.getInstance().recipeBook.add(p.getUniqueId());
+		if (!Main.getInstance().getRecipeBook().contains(p.getUniqueId()))
+			Main.getInstance().getRecipeBook().add(p.getUniqueId());
 
-		Main.getInstance().typeGUI.open(p);
+		Main.getInstance().getTypeGUI().open(p);
 		String OpenMessage = ChatColor.translateAlternateColorCodes('&', getConfig().getString("gui.Open-Message"));
 		p.sendMessage(OpenMessage);
 		p.playSound(p.getLocation(), XSound.matchXSound(getConfig().getString("gui.Open-Sound")).get().parseSound(), 1,

--- a/src/me/mehboss/commands/CommandCrafterDebug.java
+++ b/src/me/mehboss/commands/CommandCrafterDebug.java
@@ -14,21 +14,21 @@ public class CommandCrafterDebug {
 		public static boolean Run(CRCommand command) {
 
 			CommandSender p = command.sender;
-			if (Main.getInstance().crafterdebug) {
+			if (Main.getInstance().isCrafterDebug()) {
 				p.sendMessage(ChatColor.translateAlternateColorCodes('&',
 						"&c[CustomRecipes] &fCrafterDebug mode has been turned &cOFF."));
 				getConfig().set("Crafter-Debug", false);
-				Main.getInstance().crafterdebug = false;
+				Main.getInstance().setCrafterDebug(false);
 				Main.getInstance().saveConfig();
 				Main.getInstance().reloadConfig();
 				return true;
 			}
 
-			if (!(Main.getInstance().crafterdebug)) {
+			if (!(Main.getInstance().isCrafterDebug())) {
 				p.sendMessage(ChatColor.translateAlternateColorCodes('&',
 						"&c[CustomRecipes] &fCrafterDebug mode has been turned &aON.&f Check console for INFO."));
 				getConfig().set("Crafter-Debug", true);
-				Main.getInstance().crafterdebug = true;
+				Main.getInstance().setCrafterDebug(true);
 				Main.getInstance().saveConfig();
 				Main.getInstance().reloadConfig();
 				return true;

--- a/src/me/mehboss/commands/CommandCreate.java
+++ b/src/me/mehboss/commands/CommandCreate.java
@@ -16,7 +16,7 @@ import me.mehboss.utils.data.WorkstationRecipeData;
 public class CommandCreate {
 
 	static RecipeUtil getRecipeUtil() {
-		return Main.getInstance().recipeUtil;
+		return Main.getInstance().getRecipeUtil();
 	}
 
 	// Keep the method header as requested
@@ -74,7 +74,7 @@ public class CommandCreate {
 				ChatColor.translateAlternateColorCodes('&', "&c[CustomRecipes] &fPreparing to create recipe:&r "));
 		sender.sendMessage(ChatColor.translateAlternateColorCodes('&',
 				"&fType= &a" + type.toString() + " &fID= &a" + id + " &fPermission= &a" + permission));
-		Main.getInstance().recipes.showCreationMenu((Player) sender, recipe, true, false);
+		Main.getInstance().getBookGUI().showCreationMenu((Player) sender, recipe, true, false);
 		return true;
 	}
 }

--- a/src/me/mehboss/commands/CommandDebug.java
+++ b/src/me/mehboss/commands/CommandDebug.java
@@ -14,21 +14,21 @@ public class CommandDebug {
 	public static boolean Run(CRCommand command) {
 
 		CommandSender p = command.sender;
-		if (Main.getInstance().debug) {
+		if (Main.getInstance().isDebug()) {
 			p.sendMessage(ChatColor.translateAlternateColorCodes('&',
 					"&c[CustomRecipes] &fDebug mode has been turned &cOFF."));
 			getConfig().set("Debug", false);
-			Main.getInstance().debug = false;
+			Main.getInstance().setDebug(false);
 			Main.getInstance().saveConfig();
 			Main.getInstance().reloadConfig();
 			return true;
 		}
 
-		if (!(Main.getInstance().debug)) {
+		if (!(Main.getInstance().isDebug())) {
 			p.sendMessage(ChatColor.translateAlternateColorCodes('&',
 					"&c[CustomRecipes] &fDebug mode has been turned &aON.&f Check console for INFO."));
 			getConfig().set("Debug", true);
-			Main.getInstance().debug = true;
+			Main.getInstance().setDebug(true);
 			Main.getInstance().saveConfig();
 			Main.getInstance().reloadConfig();
 			return true;

--- a/src/me/mehboss/commands/CommandGUI.java
+++ b/src/me/mehboss/commands/CommandGUI.java
@@ -19,10 +19,10 @@ public class CommandGUI {
 			return false;
 		}
 		
-		if (Main.getInstance().recipeBook.contains(p.getUniqueId()))
-			Main.getInstance().recipeBook.remove(p.getUniqueId());
+		if (Main.getInstance().getRecipeBook().contains(p.getUniqueId()))
+			Main.getInstance().getRecipeBook().remove(p.getUniqueId());
 
-		Main.getInstance().typeGUI.open(p);
+		Main.getInstance().getTypeGUI().open(p);
 		String OpenMessage = ChatColor.translateAlternateColorCodes('&', getConfig().getString("gui.Open-Message"));
 		p.sendMessage(OpenMessage);
 		p.playSound(p.getLocation(),

--- a/src/me/mehboss/commands/CommandGive.java
+++ b/src/me/mehboss/commands/CommandGive.java
@@ -54,8 +54,15 @@ public class CommandGive {
 		}
 
 		// amounts
-		if (command.args.length == 4 && isInt(command.args[3]))
-			amount = Integer.parseInt(command.args[3]);
+		if (command.args.length == 4 && isInt(command.args[3])) {
+			int parsed = Integer.parseInt(command.args[3]);
+			if (parsed < 1 || parsed > item.getMaxStackSize()) {
+				p.sendMessage(getMessage("Messages.Invalid-Args",
+						"&cInvalid amount! Must be between 1 and " + item.getMaxStackSize() + "."));
+				return true;
+			}
+			amount = parsed;
+		}
 
 		item.setAmount(amount);
 		target.getInventory().addItem(item);

--- a/src/me/mehboss/commands/CommandReload.java
+++ b/src/me/mehboss/commands/CommandReload.java
@@ -21,7 +21,7 @@ public class CommandReload {
 		Main.getInstance().reload();
 		p.sendMessage(
 				ChatColor.translateAlternateColorCodes('&', getConfig().getString("Messages.Reload").replaceAll(
-						"%recipes%", String.valueOf(Main.getInstance().recipeUtil.getRecipeNames().size()))));
+						"%recipes%", String.valueOf(Main.getInstance().getRecipeUtil().getRecipeNames().size()))));
 
 		return true;
 	}

--- a/src/me/mehboss/commands/CommandRemove.java
+++ b/src/me/mehboss/commands/CommandRemove.java
@@ -11,7 +11,7 @@ import me.mehboss.utils.RecipeUtil.Recipe;
 public class CommandRemove {
 
 	static RecipeUtil getRecipeUtil() {
-	    return Main.getInstance().recipeUtil;
+	    return Main.getInstance().getRecipeUtil();
 	}
 
 	public static boolean Run(CRCommand command) {

--- a/src/me/mehboss/commands/CommandShow.java
+++ b/src/me/mehboss/commands/CommandShow.java
@@ -11,7 +11,7 @@ import me.mehboss.utils.RecipeUtil.Recipe;
 public class CommandShow {
 
 	static RecipeUtil getRecipeUtil() {
-		return Main.getInstance().recipeUtil;
+		return Main.getInstance().getRecipeUtil();
 	}
 
 	public static boolean Run(CRCommand command) {
@@ -33,7 +33,7 @@ public class CommandShow {
 
 		Player p = (Player) sender;
 		sender.sendMessage(ChatColor.RED + "[CustomRecipes] Showing recipe with ID '" + id + "'..");
-		Main.getInstance().recipes.showCreationMenu(p, existing, false, false);
+		Main.getInstance().getBookGUI().showCreationMenu(p, existing, false, false);
 		return true;
 	}
 }

--- a/src/me/mehboss/commands/TabCompletion.java
+++ b/src/me/mehboss/commands/TabCompletion.java
@@ -111,7 +111,7 @@ public class TabCompletion implements TabCompleter {
 				} else if (args.length == 4) {
 					// suggest NamespacedKeys (recipes)
 					List<String> keys = new ArrayList<>();
-					for (String key : Main.getInstance().recipeUtil.getAllRecipes().keySet()) {
+					for (String key : Main.getInstance().getRecipeUtil().getAllRecipes().keySet()) {
 						keys.add(key);
 					}
 					StringUtil.copyPartialMatches(args[3], keys, completions);
@@ -162,11 +162,11 @@ public class TabCompletion implements TabCompleter {
 	private Collection<String> getAllKeys() {
 		Set<String> combined = new HashSet<>();
 		combined.addAll(ItemManager.getAllItems());
-		combined.addAll(Main.getInstance().recipeUtil.getAllKeys());
+			combined.addAll(Main.getInstance().getRecipeUtil().getAllKeys());
 		return combined;
 	}
 
 	private Collection<String> getRecipes() {
-		return Main.getInstance().recipeUtil.getAllKeys();
+		return Main.getInstance().getRecipeUtil().getAllKeys();
 	}
 }

--- a/src/me/mehboss/cooking/CookingManager.java
+++ b/src/me/mehboss/cooking/CookingManager.java
@@ -93,7 +93,7 @@ public class CookingManager implements Listener {
 				}
 
 				if (hasCooldown) {
-					Long timeLeft = Main.getInstance().cooldownManager.getTimeLeft(p.getUniqueId(), recipe.getKey());
+					Long timeLeft = Main.getInstance().getCooldownManager().getTimeLeft(p.getUniqueId(), recipe.getKey());
 					sendMessage(p, "crafting-limit", timeLeft);
 					e.setCancelled(true);
 					return;
@@ -178,15 +178,15 @@ public class CookingManager implements Listener {
 	}
 
 	RecipeUtil getRecipeUtil() {
-		return Main.getInstance().recipeUtil;
+		return Main.getInstance().getRecipeUtil();
 	}
 
 	CooldownManager getCooldownManager() {
-		return Main.getInstance().cooldownManager;
+		return Main.getInstance().getCooldownManager();
 	}
 
 	void logDebug(String st) {
-		if (Main.getInstance().debug)
+		if (Main.getInstance().isDebug())
 			Logger.getLogger("Minecraft").log(Level.WARNING, "[DEBUG][" + Main.getInstance().getName() + "] " + st);
 	}
 

--- a/src/me/mehboss/crafting/AmountManager.java
+++ b/src/me/mehboss/crafting/AmountManager.java
@@ -44,7 +44,7 @@ public class AmountManager implements Listener {
 	}
 
 	void logDebug(String st) {
-		if (Main.getInstance().debug)
+		if (Main.getInstance().isDebug())
 			Logger.getLogger("Minecraft").log(Level.WARNING, "[DEBUG][" + Main.getInstance().getName() + "]" + st);
 	}
 
@@ -53,15 +53,15 @@ public class AmountManager implements Listener {
 	}
 
 	CooldownManager getCooldownManager() {
-		return Main.getInstance().cooldownManager;
+		return Main.getInstance().getCooldownManager();
 	}
 
 	RecipeUtil getRecipeUtil() {
-		return Main.getInstance().recipeUtil;
+		return Main.getInstance().getRecipeUtil();
 	}
 
 	ShapedChecks shapedChecks() {
-		return Main.getInstance().shapedChecks;
+		return Main.getInstance().getShapedChecks();
 	}
 
 	private boolean hasAllIngredients(CraftingInventory inv, String recipes, List<Ingredient> recipeIngredients,
@@ -187,7 +187,7 @@ public class AmountManager implements Listener {
 		logDebug("[handleShiftClicks] Fired #1");
 
 		Recipe matched = getRecipeUtil().getRecipeFromResult(inv.getResult(), true);
-		Main.getInstance().debounceMap.put(id, System.currentTimeMillis());
+		Main.getInstance().getDebounceMap().put(id, System.currentTimeMillis());
 		if (matched == null)
 			return;
 
@@ -214,7 +214,7 @@ public class AmountManager implements Listener {
 				: getRecipeUtil().getRecipesFromType(RecipeType.SHAPED);
 
 		ReadWriteNBT nbt = NBT.itemStackToNBT(inv.getResult());
-		if (nbt.hasTag("CUSTOM_ITEM_IDENTIFER")) {
+		if (nbt.hasTag("CUSTOM_ITEM_IDENTIFIER")) {
 			String foundID = nbt.getString("CUSTOM_ITEM_IDENTIFIER");
 			Recipe keyedRecipe = getRecipeUtil().getRecipeFromKey(foundID);
 			if (keyedRecipe != null)
@@ -244,7 +244,7 @@ public class AmountManager implements Listener {
 
 		// COOLDOWN
 		if (hasCooldown) {
-			Long timeLeft = Main.getInstance().cooldownManager.getTimeLeft(p.getUniqueId(), recipe.getKey());
+			Long timeLeft = Main.getInstance().getCooldownManager().getTimeLeft(p.getUniqueId(), recipe.getKey());
 			e.setCancelled(true);
 			sendMessage(p, "crafting-limit", timeLeft);
 			return;
@@ -402,8 +402,8 @@ public class AmountManager implements Listener {
 		getCooldownManager().addCooldown(player.getUniqueId(), cooldown);
 
 		// debug suppression window
-		Main.getInstance().inInventory.add(id);
-		Bukkit.getScheduler().runTaskLater(Main.getInstance(), () -> Main.getInstance().inInventory.remove(id), 2L);
+		Main.getInstance().getInInventory().add(id);
+		Bukkit.getScheduler().runTaskLater(Main.getInstance(), () -> Main.getInstance().getInInventory().remove(id), 2L);
 
 		if (recipe.hasCommands()) {
 			if (e.getAction() != InventoryAction.MOVE_TO_OTHER_INVENTORY)

--- a/src/me/mehboss/crafting/AmountManager.java
+++ b/src/me/mehboss/crafting/AmountManager.java
@@ -15,12 +15,13 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.event.inventory.CraftItemEvent;
+import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryAction;
 import org.bukkit.event.inventory.PrepareItemCraftEvent;
+import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.CraftingInventory;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.ShapelessRecipe;
 
 import com.cryptomorin.xseries.XMaterial;
 
@@ -44,8 +45,8 @@ public class AmountManager implements Listener {
 	}
 
 	void logDebug(String st) {
-		if (Main.getInstance().isDebug())
-			Logger.getLogger("Minecraft").log(Level.WARNING, "[DEBUG][" + Main.getInstance().getName() + "]" + st);
+		// Always log for debugging item removal issues
+		Logger.getLogger("Minecraft").log(Level.WARNING, "[DEBUG-ITEMREMOVAL][" + Main.getInstance().getName() + "]" + st);
 	}
 
 	void sendMessage(Player p, String s, long seconds) {
@@ -74,45 +75,46 @@ public class AmountManager implements Listener {
 	}
 
 	// Helper method for the handleShiftClick method
-	void handlesItemRemoval(CraftItemEvent e, CraftingInventory inv, CraftingRecipeData recipe, ItemStack item,
+	void handlesItemRemoval(InventoryClickEvent e, CraftingInventory inv, CraftingRecipeData recipe, ItemStack item,
 			RecipeUtil.Ingredient ingredient, int slot, int itemsToRemove, int itemsToAdd, int requiredAmount,
 			AtomicBoolean containerCraft) {
 
 		String recipeName = recipe.getName();
-		logDebug("[handleShiftClicks] Checking slot " + slot + " for the recipe " + recipeName);
+		logDebug("[ENTERED-handlesItemRemoval] slot=" + slot + ", currentAmount=" + item.getAmount() + 
+			", itemsToRemove=" + itemsToRemove + ", requiredAmount=" + requiredAmount + ", recipe=" + recipeName);
 
 		if (matchesIngredient(item, recipeName, ingredient)) {
 
-			itemsToRemove = itemsToAdd * requiredAmount;
-
 			int availableItems = item.getAmount();
 
-			logDebug("[handleShiftClicks] ItemsToRemove: " + itemsToRemove + " || ItemsToAdd: " + itemsToAdd);
-			logDebug("[handleShiftClicks] ItemAmount: " + availableItems + " || RequiredAmount: " + requiredAmount);
+			logDebug("[handleShiftClicks] PARAM_SLOT=" + slot + ", itemsToAdd=" + itemsToAdd + ", requiredAmount=" + requiredAmount + ", itemsToRemove_param=" + itemsToRemove);
+			logDebug("[handleShiftClicks] ItemsToRemove CALC: " + itemsToRemove + " (itemsToAdd=" + itemsToAdd + " * requiredAmount=" + requiredAmount + ")");
+			logDebug("[handleShiftClicks] ItemsToAdd: " + itemsToAdd);
+			logDebug("[handleShiftClicks] ItemAmount (available): " + availableItems + " || RequiredAmount: " + requiredAmount);
 			logDebug("[handleShiftClicks] Identifier: " + ingredient.getIdentifier() + " || hasID: "
 					+ ingredient.hasIdentifier());
 			logDebug("[handleShiftClicks] Material: " + ingredient.getMaterial().toString() + " || Displayname: "
 					+ ingredient.getDisplayName());
 
-			if (availableItems < requiredAmount)
-				return;
-
-			String id = ingredient.hasIdentifier() ? ingredient.getIdentifier() : item.getType().toString();
-			if (recipe.isLeftover(id)) {
-				logDebug("[isLeftover] Leaving item in the work bench because it has been listed to be leftover!");
-				if (item.getType().toString().contains("_BUCKET"))
-					item.setType(XMaterial.BUCKET.parseMaterial());
-
-				item.setAmount(item.getAmount() + 1);
+			if (availableItems < requiredAmount) {
+				logDebug("[handleShiftClicks] REJECTED: availableItems (" + availableItems + ") < requiredAmount (" + requiredAmount + ")");
 				return;
 			}
 
-			if (e.getAction() != InventoryAction.MOVE_TO_OTHER_INVENTORY) {
-				if (item.getAmount() == 1 && !containerCraft.get())
-					return;
+			String id = ingredient.hasIdentifier() ? ingredient.getIdentifier() : item.getType().toString();
+			logDebug("[handleShiftClicks] id_resolved=" + id + ", isLeftover=" + recipe.isLeftover(id));
+
+			// Leftovers are handled automatically by Minecraft - don't modify amount here
+			// This prevents stack overflow when PrepareItemCraftEvent fires multiple times
+
+			if (recipe.isLeftover(id)) {
+				logDebug("[isLeftover] BRANCH=LEFTOVER: id=" + id + ", currentAmount=" + item.getAmount() + ", requiredAmount=" + requiredAmount);
+				if (item.getType().toString().contains("_BUCKET"))
+					item.setType(XMaterial.BUCKET.parseMaterial());
 
 				if (((item.getAmount()) - requiredAmount == 0)) {
 					if (containerCraft.get() && !recipe.isLeftover(id)) {
+						logDebug("[isLeftover-path1a] CONTAINER_EMPTY: setting slot to null");
 						Bukkit.getScheduler().runTask(Main.getInstance(), () -> {
 							inv.setItem(slot, null);
 						});
@@ -120,29 +122,45 @@ public class AmountManager implements Listener {
 					}
 					// set to 1, not 0, since we don't cancel the event. Vanilla will handle the
 					// leftover.
+					logDebug("[isLeftover-path1b] SETTING_TO_1: beforeAmount=" + item.getAmount());
 					item.setAmount(1);
+					logDebug("[isLeftover-path1b] AFTER_SET: amount=" + item.getAmount());
 				} else {
 					if (containerCraft.get()) {
 						// remove exact, since containers are cancelled, normal vanilla deduction does
 						// not happen.
-						item.setAmount((item.getAmount()) - requiredAmount);
+						int newAmount = (item.getAmount()) - requiredAmount;
+						logDebug("[isLeftover-path2a] CONTAINER_EXACT_REMOVE: beforeAmount=" + item.getAmount() + ", requiredAmount=" + requiredAmount + ", calculatedNew=" + newAmount);
+						item.setAmount(newAmount);
+						logDebug("[isLeftover-path2a] AFTER_SET: amount=" + item.getAmount());
 						return;
 					}
-					item.setAmount((item.getAmount()) - (requiredAmount - 1));
+					int newAmount = (item.getAmount()) - (requiredAmount - 1);
+					logDebug("[isLeftover-path2b] NORMAL_REMOVE_MINUS_1: beforeAmount=" + item.getAmount() + ", requiredAmount=" + requiredAmount + ", calculatedNew=" + newAmount);
+					item.setAmount(newAmount);
+					logDebug("[isLeftover-path2b] AFTER_SET: amount=" + item.getAmount());
 				}
 			} else {
-				if ((item.getAmount() - itemsToRemove) <= 0) {
+				logDebug("[NO_LEFTOVER] BRANCH=NORMAL: id=" + id + ", currentAmount=" + item.getAmount() + ", itemsToRemove=" + itemsToRemove);
+				int calcResult = item.getAmount() - itemsToRemove;
+				logDebug("[NO_LEFTOVER] CALC: " + item.getAmount() + " - " + itemsToRemove + " = " + calcResult);
+				if (calcResult <= 0) {
+					logDebug("[NO_LEFTOVER-path1] WILL_BE_EMPTY: calcResult=" + calcResult);
 					if (containerCraft.get() && !recipe.isLeftover(id)) {
+						logDebug("[NO_LEFTOVER-path1a] CONTAINER_EMPTY: setting slot to null, id=" + id);
 						Bukkit.getScheduler().runTask(Main.getInstance(), () -> {
 							inv.setItem(slot, null);
 						});
 						return;
 					}
+					logDebug("[NO_LEFTOVER-path1b] NORMAL_EMPTY: setting slot to null");
 					inv.setItem(slot, null);
 					return;
 				}
 
+				logDebug("[NO_LEFTOVER-path2] PARTIAL_REMOVE: beforeAmount=" + item.getAmount() + ", toRemove=" + itemsToRemove);
 				item.setAmount(item.getAmount() - (itemsToRemove));
+				logDebug("[NO_LEFTOVER-path2] AFTER_SET: amount=" + item.getAmount());
 			}
 		}
 	}
@@ -172,32 +190,66 @@ public class AmountManager implements Listener {
 		return item == null || item.getType() == Material.AIR;
 	}
 
-	@EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
-	void handleShiftClicks(CraftItemEvent e) {
-		CraftingInventory inv = e.getInventory();
+	@EventHandler(priority = EventPriority.HIGHEST)
+	public void handleShiftClicks(CraftItemEvent e) {
+		handleResultClickInternal(e, true);
+	}
+
+	private boolean isResultSlotClick(InventoryClickEvent e) {
+		if (e.getClickedInventory() == null)
+			return false;
+		if (!(e.getInventory() instanceof CraftingInventory))
+			return false;
+		if (e.getView().getTopInventory().getType() != InventoryType.WORKBENCH
+				&& e.getView().getTopInventory().getType() != InventoryType.CRAFTING)
+			return false;
+		return e.getRawSlot() == 0;
+	}
+
+	private void handleResultClickInternal(InventoryClickEvent e, boolean sourceIsCraftItemEvent) {
+		if (!sourceIsCraftItemEvent && !isResultSlotClick(e))
+			return;
+
+		CraftingInventory inv = (CraftingInventory) e.getInventory();
 		UUID id = e.getWhoClicked().getUniqueId();
+		long now = System.currentTimeMillis();
+		Long lastHandled = Main.getInstance().getDebounceMap().get(id);
+
+		// Guard against duplicate result-click events fired for the same physical click.
+		if (lastHandled != null && now - lastHandled < 40) {
+			logDebug("[handleShiftClicks] Suppressed duplicate result click: deltaMs=" + (now - lastHandled)
+					+ ", action=" + e.getAction() + ", click=" + e.getClick());
+			e.setCancelled(true);
+			return;
+		}
+
+		Main.getInstance().getDebounceMap().put(id, now);
 		Player p = (Player) e.getWhoClicked();
 		Inventory playerInventory = e.getWhoClicked().getInventory();
 		boolean isInvFull = playerInventory.firstEmpty() == -1;
 
-		if (inv.getResult() == null || inv.getResult().getType() == Material.AIR)
+		logDebug("[handleShiftClicks] EVENT_FIRED: class=" + e.getClass().getSimpleName() + ", action=" + e.getAction()
+				+ ", click=" + e.getClick() + ", cancelled=" + e.isCancelled() + ", sourceIsCraftItemEvent="
+				+ sourceIsCraftItemEvent);
+		if (e.isCancelled())
 			return;
 
-		// debounce
-		logDebug("[handleShiftClicks] Fired #1");
+		ItemStack eventResult = inv.getResult();
+		if (eventResult == null || eventResult.getType() == Material.AIR)
+			eventResult = e.getCurrentItem();
 
-		Recipe matched = getRecipeUtil().getRecipeFromResult(inv.getResult(), true);
-		Main.getInstance().getDebounceMap().put(id, System.currentTimeMillis());
+		if (eventResult == null || eventResult.getType() == Material.AIR)
+			return;
+
+		Recipe matched = getRecipeUtil().getRecipeFromResult(eventResult, true);
 		if (matched == null)
 			return;
-
-		logDebug("[handleShiftClicks] Fired #2");
 
 		if (e.getCurrentItem() == null || e.getCurrentItem().getType() == Material.AIR)
 			return;
 
 		boolean isValidButton = e.getHotbarButton() != -1;
-		if (e.isCancelled() || e.getAction() == InventoryAction.HOTBAR_MOVE_AND_READD
+		if (e.getAction() == InventoryAction.HOTBAR_MOVE_AND_READD
 				|| (e.getClick() == ClickType.NUMBER_KEY && isInvFull)
 				|| (isValidButton && !isSlotEmpty(e.getHotbarButton(), playerInventory))) {
 			logDebug("[handleShiftClicks] Denying craft due to failed hotbar move..");
@@ -206,22 +258,28 @@ public class AmountManager implements Listener {
 		}
 
 		ItemStack cursor = e.getCursor();
-		ItemStack result = inv.getResult();
+		ItemStack result = eventResult;
 		String findName = matched.getName();
-		boolean isShapeless = e.getRecipe() instanceof ShapelessRecipe;
+		boolean isShapeless = matched.getType() == RecipeType.SHAPELESS;
 
 		HashMap<String, Recipe> types = isShapeless ? getRecipeUtil().getRecipesFromType(RecipeType.SHAPELESS)
 				: getRecipeUtil().getRecipesFromType(RecipeType.SHAPED);
 
-		ReadWriteNBT nbt = NBT.itemStackToNBT(inv.getResult());
-		if (nbt.hasTag("CUSTOM_ITEM_IDENTIFIER")) {
+		ReadWriteNBT nbt = null;
+		try {
+			if (result.getAmount() > 0 && result.getAmount() <= result.getMaxStackSize())
+				nbt = NBT.itemStackToNBT(result);
+		} catch (Exception ex) {
+			logDebug("[handleShiftClicks] Failed to read result NBT due to invalid stack. Continuing with fallback recipe name.");
+		}
+
+		if (nbt != null && nbt.hasTag("CUSTOM_ITEM_IDENTIFIER")) {
 			String foundID = nbt.getString("CUSTOM_ITEM_IDENTIFIER");
 			Recipe keyedRecipe = getRecipeUtil().getRecipeFromKey(foundID);
 			if (keyedRecipe != null)
 				findName = keyedRecipe.getName();
 		}
 
-		// safeguard: match correct custom recipe result
 		if (types != null)
 			for (Recipe r : types.values()) {
 				ItemStack itm = r.getResult();
@@ -242,7 +300,6 @@ public class AmountManager implements Listener {
 				&& getCooldownManager().hasCooldown(p.getUniqueId(), recipe.getKey())
 				&& !(recipe.hasPerm() && p.hasPermission(recipe.getPerm() + ".bypass"));
 
-		// COOLDOWN
 		if (hasCooldown) {
 			Long timeLeft = Main.getInstance().getCooldownManager().getTimeLeft(p.getUniqueId(), recipe.getKey());
 			e.setCancelled(true);
@@ -264,8 +321,6 @@ public class AmountManager implements Listener {
 			}
 		}
 
-		// prevents "ghost crafts" where the item isn't supposed to craft, but
-		// CraftItemEvent still fires.
 		if (cursor != null && cursor.getType() != Material.AIR) {
 			boolean canStackWithResult = cursor.isSimilar(result)
 					&& cursor.getAmount() + result.getAmount() <= cursor.getMaxStackSize();
@@ -278,42 +333,31 @@ public class AmountManager implements Listener {
 
 		RecipeType type = recipe.getType();
 
-		// ============================================================
-		// PASS 1 — ITEMS TO ADD
-		// ============================================================
-		int itemsToAdd = Integer.MAX_VALUE;
-		int itemsToRemove = 0;
-
+		int maxCrafts = Integer.MAX_VALUE;
 		ShapedChecks.AlignedResult aligned = null;
 
 		if (type == RecipeType.SHAPED) {
-
 			aligned = shapedChecks().getAlignedGrid(inv, recipe.getIngredients());
 			if (aligned == null) {
-				// cannot craft at all
-				itemsToAdd = 0;
+				maxCrafts = 0;
 			} else {
-
 				for (int i = 0; i < recipe.getIngredients().size(); i++) {
-
 					Ingredient ing = recipe.getIngredients().get(i);
 					if (ing.isEmpty())
 						continue;
 
 					ItemStack stack = aligned.getMatrix[i];
 					if (stack == null || stack.getType() == Material.AIR) {
-						itemsToAdd = 0;
+						maxCrafts = 0;
 						break;
 					}
 
 					int requiredAmount = Math.max(1, ing.getAmount());
 					int possible = stack.getAmount() / requiredAmount;
-					itemsToAdd = Math.min(itemsToAdd, possible);
+					maxCrafts = Math.min(maxCrafts, possible);
 				}
 			}
-
 		} else {
-			// shapeless
 			for (Ingredient ing : recipe.getIngredients()) {
 				if (ing.isEmpty())
 					continue;
@@ -328,55 +372,62 @@ public class AmountManager implements Listener {
 						continue;
 
 					int possible = slot.getAmount() / req;
-					itemsToAdd = Math.min(itemsToAdd, possible);
+					maxCrafts = Math.min(maxCrafts, possible);
 				}
 			}
 		}
 
-		if (itemsToAdd <= 0 || itemsToAdd == Integer.MAX_VALUE) {
+		if (maxCrafts <= 0 || maxCrafts == Integer.MAX_VALUE) {
 			logDebug("[handleShiftClicks][" + findName
 					+ "] Issue detected while attempting amount deductions. If this is in error, please reach out for support.");
 			e.setCancelled(true);
 			return;
 		}
 
+		int craftsToProcess = e.getAction() == InventoryAction.MOVE_TO_OTHER_INVENTORY ? maxCrafts : 1;
+
 		boolean recipeHasContainer = recipe.getAllIngredientTypes().stream()
 				.anyMatch(mat -> mat == XMaterial.DRAGON_BREATH.get() || mat == XMaterial.POTION.get()
 						|| mat == XMaterial.LINGERING_POTION.get() || mat.toString().contains("_BUCKET"));
 		AtomicBoolean containerCraft = new AtomicBoolean(recipeHasContainer);
 
-		// ============================================================
-		// PASS 2 — REMOVE ITEMS
-		// ============================================================
 		if (type == RecipeType.SHAPED) {
+			boolean[] handledSlots = new boolean[10];
 
 			for (int i = 0; i < recipe.getIngredients().size(); i++) {
-
 				Ingredient ing = recipe.getIngredients().get(i);
 				if (ing.isEmpty())
 					continue;
 
 				int realInvSlot = aligned.invSlotMap[i];
+				if (realInvSlot < 0 || realInvSlot >= handledSlots.length || handledSlots[realInvSlot])
+					continue;
 				ItemStack stack = inv.getItem(realInvSlot);
 				if (stack == null || stack.getType() == Material.AIR)
 					continue;
 
 				int requiredAmount = Math.max(1, ing.getAmount());
+				int amountToRemove = craftsToProcess * requiredAmount;
 
-				handlesItemRemoval(e, inv, recipe, stack, ing, realInvSlot, itemsToRemove, itemsToAdd, requiredAmount,
-						containerCraft);
+				logDebug("[handleShaped] CALLING handlesItemRemoval for slot " + realInvSlot + ", ingredient="
+						+ ing.getIdentifier() + ", currentAmount=" + stack.getAmount() + ", amountToRemove="
+						+ amountToRemove + " (craftsToProcess=" + craftsToProcess + " * requiredAmount="
+						+ requiredAmount + ")");
+				handlesItemRemoval(e, inv, recipe, stack, ing, realInvSlot, amountToRemove, craftsToProcess,
+						requiredAmount, containerCraft);
+				logDebug("[handleShaped] AFTER handlesItemRemoval for slot " + realInvSlot + ", newAmount="
+						+ stack.getAmount());
+				handledSlots[realInvSlot] = true;
 			}
-
 		} else {
-			// shapeless
 			boolean[] handledSlots = new boolean[9];
 			for (Ingredient ing : recipe.getIngredients()) {
 				if (ing.isEmpty())
 					continue;
 
 				int req = Math.max(1, ing.getAmount());
+				int amountToRemove = craftsToProcess * req;
 
-				// add 1 for inventory matrix
 				for (int i = 1; i < 10; i++) {
 					ItemStack stack = inv.getItem(i);
 
@@ -388,28 +439,30 @@ public class AmountManager implements Listener {
 					if (!matchesIngredient(stack, findName, ing))
 						continue;
 
-					handlesItemRemoval(e, inv, recipe, stack, ing, i, itemsToRemove, itemsToAdd, req, containerCraft);
+					logDebug("[handleShapeless] CALLING handlesItemRemoval for slot " + i + ", ingredient="
+							+ ing.getIdentifier() + ", currentAmount=" + stack.getAmount() + ", amountToRemove="
+							+ amountToRemove + " (craftsToProcess=" + craftsToProcess + " * req=" + req + ")");
+					handlesItemRemoval(e, inv, recipe, stack, ing, i, amountToRemove, craftsToProcess, req,
+							containerCraft);
+					logDebug("[handleShapeless] AFTER handlesItemRemoval for slot " + i + ", newAmount="
+							+ stack.getAmount());
 					handledSlots[(i - 1)] = true;
 				}
 			}
 		}
 
-		// ============================================================
-		// COMMANDS + OUTPUT
-		// ============================================================
 		Player player = (Player) e.getWhoClicked();
 		Cooldown cooldown = new Cooldown(recipe.getKey(), recipe.getCooldown());
 		getCooldownManager().addCooldown(player.getUniqueId(), cooldown);
 
-		// debug suppression window
 		Main.getInstance().getInInventory().add(id);
 		Bukkit.getScheduler().runTaskLater(Main.getInstance(), () -> Main.getInstance().getInInventory().remove(id), 2L);
 
 		if (recipe.hasCommands()) {
 			if (e.getAction() != InventoryAction.MOVE_TO_OTHER_INVENTORY)
-				itemsToAdd = 1;
+				craftsToProcess = 1;
 
-			for (int n = 0; n < itemsToAdd; n++)
+			for (int n = 0; n < craftsToProcess; n++)
 				for (String cmd : recipe.getCommand())
 					Bukkit.dispatchCommand(Bukkit.getConsoleSender(), cmd.replace("%crafter%", player.getName()));
 
@@ -423,32 +476,49 @@ public class AmountManager implements Listener {
 		if (e.getAction() != InventoryAction.MOVE_TO_OTHER_INVENTORY) {
 			logDebug("[handleShiftClicks] Normal click, no mass-add");
 
+			if (!sourceIsCraftItemEvent)
+				e.setCancelled(true);
+
 			if (containerCraft.get()) {
 				e.setCancelled(true);
 
 				logDebug("[handleShiftClicks] Manual handle of container, since vanilla mechanics replace.");
 				if (cursor == null || cursor.getType() == Material.AIR)
 					player.setItemOnCursor(result.clone());
-				else if (cursor.isSimilar(result))
-					cursor.setAmount(cursor.getAmount() + result.getAmount());
-				else
+				else if (cursor.isSimilar(result)) {
+					int newAmount = Math.min(cursor.getAmount() + result.getAmount(), cursor.getMaxStackSize());
+					cursor.setAmount(newAmount);
+				} else
 					return;
 
-				// since we cancel, we have to retrigger an evaluation manually
 				Bukkit.getScheduler().runTask(Main.getInstance(), () -> {
 					PrepareItemCraftEvent event = new PrepareItemCraftEvent(inv, e.getView(), false);
 					Bukkit.getPluginManager().callEvent(event);
 				});
 			}
 
-			if (itemsToAdd == 1)
+			if (!sourceIsCraftItemEvent && !containerCraft.get()) {
+				if (cursor == null || cursor.getType() == Material.AIR)
+					player.setItemOnCursor(result.clone());
+				else if (cursor.isSimilar(result)) {
+					int newAmount = Math.min(cursor.getAmount() + result.getAmount(), cursor.getMaxStackSize());
+					cursor.setAmount(newAmount);
+				} else
+					return;
+
+				Bukkit.getScheduler().runTask(Main.getInstance(), () -> {
+					PrepareItemCraftEvent event = new PrepareItemCraftEvent(inv, e.getView(), false);
+					Bukkit.getPluginManager().callEvent(event);
+				});
+			}
+
+			if (craftsToProcess == 1)
 				Bukkit.getScheduler().runTask(Main.getInstance(), () -> {
 					inv.setResult(new ItemStack(Material.AIR));
 				});
 			return;
 		}
 
-		// SHIFT CLICK OUTPUT
 		e.setCancelled(true);
 
 		if (recipe.hasCommands() && !recipe.isGrantItem())
@@ -456,13 +526,32 @@ public class AmountManager implements Listener {
 
 		inv.setResult(new ItemStack(Material.AIR));
 
-		for (int i = 0; i < itemsToAdd; i++) {
+		for (int i = 0; i < craftsToProcess; i++) {
 			if (player.getInventory().firstEmpty() == -1)
 				player.getWorld().dropItem(player.getLocation(), result.clone());
 			else
 				player.getInventory().addItem(result.clone());
 		}
 
-		logDebug("[handleShiftClicks] Added x" + itemsToAdd);
+		logDebug("[handleShiftClicks] Added x" + craftsToProcess);
+	}
+
+	@EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+	public void traceResultSlotClicks(InventoryClickEvent e) {
+		if (!isResultSlotClick(e))
+			return;
+
+		CraftingInventory ci = (CraftingInventory) e.getInventory();
+		ItemStack current = e.getCurrentItem();
+		String cur = current == null ? "null" : current.getType() + "x" + current.getAmount();
+		String res = ci.getResult() == null ? "null" : ci.getResult().getType() + "x" + ci.getResult().getAmount();
+		String recipe = ci.getRecipe() == null ? "null" : ci.getRecipe().getClass().getSimpleName();
+
+		logDebug("[traceResultSlotClicks] class=" + e.getClass().getSimpleName() + ", action=" + e.getAction()
+				+ ", click=" + e.getClick() + ", cancelled=" + e.isCancelled() + ", current=" + cur + ", invResult=" + res
+				+ ", invRecipe=" + recipe);
+
+		if (!(e instanceof CraftItemEvent))
+			handleResultClickInternal(e, false);
 	}
 }

--- a/src/me/mehboss/crafting/CraftManager.java
+++ b/src/me/mehboss/crafting/CraftManager.java
@@ -62,11 +62,11 @@ import me.mehboss.utils.libs.RecipeConditions.ConditionSet;
 public class CraftManager implements Listener {
 
 	FileConfiguration customConfig() {
-		return Main.getInstance().customConfig;
+		return Main.getInstance().getCustomConfig();
 	}
 
 	ArrayList<String> disabledrecipe() {
-		return Main.getInstance().disabledrecipe;
+		return Main.getInstance().getDisabledRecipes();
 	}
 
 	Logger getLogger() {
@@ -74,19 +74,19 @@ public class CraftManager implements Listener {
 	}
 
 	CooldownManager getCooldownManager() {
-		return Main.getInstance().cooldownManager;
+		return Main.getInstance().getCooldownManager();
 	}
 
 	RecipeUtil getRecipeUtil() {
-		return Main.getInstance().recipeUtil;
+		return Main.getInstance().getRecipeUtil();
 	}
 
 	ShapedChecks shapedChecks() {
-		return Main.getInstance().shapedChecks;
+		return Main.getInstance().getShapedChecks();
 	}
 
 	ShapelessChecks shapelessChecks() {
-		return Main.getInstance().shapelessChecks;
+		return Main.getInstance().getShapelessChecks();
 	}
 
 	boolean isInt(String s) {
@@ -99,13 +99,13 @@ public class CraftManager implements Listener {
 	}
 
 	void logDebug(String st, String recipeName, UUID id) {
-		if (Main.getInstance().debug && (id == null || (!Main.getInstance().inInventory.contains(id))))
+		if (Main.getInstance().isDebug() && (id == null || (!Main.getInstance().getInInventory().contains(id))))
 			Logger.getLogger("Minecraft").log(Level.WARNING,
 					"[DEBUG][" + Main.getInstance().getName() + "][Crafting][" + recipeName + "]" + st);
 	}
 
 	void logDebug(String st, String recipeName) {
-		if (Main.getInstance().debug)
+		if (Main.getInstance().isDebug())
 			Logger.getLogger("Minecraft").log(Level.WARNING,
 					"[DEBUG][" + Main.getInstance().getName() + "][Crafting][" + recipeName + "]" + st);
 	}
@@ -269,7 +269,7 @@ public class CraftManager implements Listener {
 
 		UUID pID = p.getUniqueId();
 
-		for (String entry : Main.getInstance().disabledrecipe) {
+		for (String entry : Main.getInstance().getDisabledRecipes()) {
 			if (customConfig().isConfigurationSection("vanilla-recipes." + entry)) {
 
 				Optional<XMaterial> match = XMaterial.matchXMaterial(entry);
@@ -545,11 +545,11 @@ public class CraftManager implements Listener {
 		UUID id = p.getUniqueId();
 
 		// avoids redundant checks to increase server performance
-		if (Main.getInstance().debounceMap.containsKey(id)) {
-			if (now - Main.getInstance().debounceMap.get(id) < 25) {
+		if (Main.getInstance().getDebounceMap().containsKey(id)) {
+			if (now - Main.getInstance().getDebounceMap().get(id) < 25) {
 				return;
 			}
-			Main.getInstance().debounceMap.remove(id);
+			Main.getInstance().getDebounceMap().remove(id);
 		}
 
 		if (isBlacklisted(inv.getResult(), p, e.getRecipe())) {
@@ -688,7 +688,7 @@ public class CraftManager implements Listener {
 							+ ChatColor.GRAY + String.join(", ", reasons));
 				}
 
-				Boolean closeInventory = Main.getInstance().customConfig.getBoolean("conditions-failed.close-inventory",
+				Boolean closeInventory = Main.getInstance().getCustomConfig().getBoolean("conditions-failed.close-inventory",
 						true);
 
 				if (closeInventory)

--- a/src/me/mehboss/crafting/CraftManager.java
+++ b/src/me/mehboss/crafting/CraftManager.java
@@ -147,6 +147,9 @@ public class CraftManager implements Listener {
 		if (item == null)
 			return returnType;
 
+		if (debug)
+			logDebug("[validateItem][Slot " + slot + "] BEFORE validation: type=" + (item.getType().toString()) + ", amount=" + item.getAmount() + ", required=" + ingredient.getAmount(), recipeName);
+
 		ItemStack recipeResult = null;
 		Recipe foundRecipe = getRecipeUtil().getRecipeFromResult(item);
 		if (foundRecipe != null) {
@@ -188,6 +191,7 @@ public class CraftManager implements Listener {
 
 			if (item.getAmount() < ingredient.getAmount()) {
 				if (debug) {
+					logDebug("[validateItem][Slot " + slot + "] FAILED amount check: have " + item.getAmount() + ", need " + ingredient.getAmount(), recipeName);
 					logDebug("[amountsMatch] Item amount: " + item.getAmount(), recipeName);
 					logDebug("[amountsMatch] Required amount: " + ingredient.getAmount(), recipeName);
 				}
@@ -195,7 +199,7 @@ public class CraftManager implements Listener {
 			}
 
 			if (debug)
-				logDebug("[amountsMatch] Item amount and ingredient amounts matched (#" + ingredient.getAmount() + ")",
+				logDebug("[validateItem][Slot " + slot + "] PASSED: amount check (have " + item.getAmount() + ", need " + ingredient.getAmount() + ")",
 						recipeName);
 
 			return true;
@@ -333,8 +337,16 @@ public class CraftManager implements Listener {
 			return true;
 
 		ItemMeta meta = item.getItemMeta();
-		ReadWriteNBT nbt = NBT.itemStackToNBT(item);
-		String id = nbt.hasTag("CUSTOM_ITEM_IDENTIFIER") ? nbt.getString("CUSTOM_ITEM_IDENTIFIER") : "none";
+		String id = "none";
+		try {
+			if (item.getAmount() > 0 && item.getAmount() <= item.getMaxStackSize()) {
+				ReadWriteNBT nbt = NBT.itemStackToNBT(item);
+				id = nbt.hasTag("CUSTOM_ITEM_IDENTIFIER") ? nbt.getString("CUSTOM_ITEM_IDENTIFIER") : "none";
+			}
+		} catch (Exception ex) {
+			logDebug("[hasMatchingDisplayName] Failed to read NBT from ingredient item. Treating as non-custom.",
+					recipeName);
+		}
 
 		if (ingredient.hasIdentifier() && ingredient.getIdentifier().equals(id))
 			return true;
@@ -573,6 +585,8 @@ public class CraftManager implements Listener {
 		World w = p.getWorld();
 		AlignedResult alignedGrid = null;
 
+		sanitizeCraftingMatrix(inv, id);
+
 		for (Recipe data : getRecipeUtil().getAllRecipesSortedByResult(inv.getResult())) {
 			if (data.getType() != RecipeType.SHAPELESS && data.getType() != RecipeType.SHAPED)
 				continue;
@@ -726,5 +740,34 @@ public class CraftManager implements Listener {
 			logDebug(" Final Recipe: " + inv.getRecipe(), recipe.getName(), id);
 			inv.setResult(item);
 		}
+
+	}
+
+	private void sanitizeCraftingMatrix(CraftingInventory inv, UUID id) {
+		ItemStack[] matrix = inv.getMatrix();
+		boolean changed = false;
+
+		for (int i = 0; i < matrix.length; i++) {
+			ItemStack stack = matrix[i];
+			if (stack == null || stack.getType() == Material.AIR)
+				continue;
+
+			int max = stack.getMaxStackSize();
+			if (max <= 0)
+				max = 64;
+
+			if (stack.getAmount() > max) {
+				logDebug("[sanitizeCraftingMatrix] Clamping invalid stack amount in slot " + i + " from "
+						+ stack.getAmount() + " to " + max, "", id);
+				stack.setAmount(max);
+				changed = true;
+			} else if (stack.getAmount() <= 0) {
+				matrix[i] = null;
+				changed = true;
+			}
+		}
+
+		if (changed)
+			inv.setMatrix(matrix);
 	}
 }

--- a/src/me/mehboss/crafting/CrafterManager.java
+++ b/src/me/mehboss/crafting/CrafterManager.java
@@ -129,7 +129,7 @@ public class CrafterManager implements Listener {
 
 		Location location = crafter.getBlock().getLocation();
 		if (!recipe.isActive() || recipe.getDisabledWorlds().contains(location.getWorld().getName())
-				|| Main.getInstance().disabledrecipe.contains(recipe.getKey()) || recipe.hasCommands()) {
+				|| Main.getInstance().getDisabledRecipes().contains(recipe.getKey()) || recipe.hasCommands()) {
 
 			logDebug(" Attempt to craft recipe was detected, but recipe is disabled!", recipe.getName());
 			return new ItemStack(Material.AIR);
@@ -252,27 +252,27 @@ public class CrafterManager implements Listener {
 	}
 
 	RecipeUtil getRecipeUtil() {
-		return Main.getInstance().recipeUtil;
+		return Main.getInstance().getRecipeUtil();
 	}
 
 	ShapedChecks shapedChecks() {
-		return Main.getInstance().shapedChecks;
+		return Main.getInstance().getShapedChecks();
 	}
 
 	ShapelessChecks shapelessChecks() {
-		return Main.getInstance().shapelessChecks;
+		return Main.getInstance().getShapelessChecks();
 	}
 
 	CraftManager CraftManager() {
-		return Main.getInstance().craftManager;
+		return Main.getInstance().getCraftManager();
 	}
 
 	AmountManager AmountManager() {
-		return Main.getInstance().amountManager;
+		return Main.getInstance().getAmountManager();
 	}
 
 	void logDebug(String st, String recipeName) {
-		if (Main.getInstance().crafterdebug)
+		if (Main.getInstance().isCrafterDebug())
 			Logger.getLogger("Minecraft").log(Level.WARNING,
 					"[DEBUG][" + Main.getInstance().getName() + "][Crafting][" + recipeName + "]" + st);
 	}

--- a/src/me/mehboss/crafting/ShapedChecks.java
+++ b/src/me/mehboss/crafting/ShapedChecks.java
@@ -303,17 +303,17 @@ public class ShapedChecks {
 	}
 
 	RecipeUtil getRecipeUtil() {
-		return Main.getInstance().recipeUtil;
+		return Main.getInstance().getRecipeUtil();
 	}
 
 	void logDebug(String st, String recipeName, UUID id) {
-		if (Main.getInstance().debug && (id == null || (!Main.getInstance().inInventory.contains(id))))
+		if (Main.getInstance().isDebug() && (id == null || (!Main.getInstance().getInInventory().contains(id))))
 			Logger.getLogger("Minecraft").log(Level.WARNING,
 					"[DEBUG][" + Main.getInstance().getName() + "][Crafting][" + recipeName + "]" + st);
 	}
 
 	void logDebug(String st, String recipeName) {
-		if (Main.getInstance().debug)
+		if (Main.getInstance().isDebug())
 			Logger.getLogger("Minecraft").log(Level.WARNING,
 					"[DEBUG][" + Main.getInstance().getName() + "][Crafting][" + recipeName + "]" + st);
 	}

--- a/src/me/mehboss/crafting/ShapelessChecks.java
+++ b/src/me/mehboss/crafting/ShapelessChecks.java
@@ -303,17 +303,17 @@ public class ShapelessChecks {
 	}
 
 	RecipeUtil getRecipeUtil() {
-		return Main.getInstance().recipeUtil;
+		return Main.getInstance().getRecipeUtil();
 	}
 
 	void logDebug(String st, String recipeName, UUID id) {
-		if (Main.getInstance().debug && (id == null || (!Main.getInstance().inInventory.contains(id))))
+		if (Main.getInstance().isDebug() && (id == null || (!Main.getInstance().getInInventory().contains(id))))
 			Logger.getLogger("Minecraft").log(Level.WARNING,
 					"[DEBUG][" + Main.getInstance().getName() + "][Crafting][" + recipeName + "]" + st);
 	}
 
 	void logDebug(String st, String recipeName) {
-		if (Main.getInstance().debug)
+		if (Main.getInstance().isDebug())
 			Logger.getLogger("Minecraft").log(Level.WARNING,
 					"[DEBUG][" + Main.getInstance().getName() + "][Crafting][" + recipeName + "]" + st);
 	}

--- a/src/me/mehboss/gui/BookGUI.java
+++ b/src/me/mehboss/gui/BookGUI.java
@@ -66,8 +66,8 @@ public class BookGUI implements Listener {
 
 	public List<RecipeUtil.Recipe> buildRecipesFor(Player p, RecipeType type, Boolean isViewing) {
 		HashMap<String, RecipeUtil.Recipe> recipesMap = (type != null)
-				? Main.getInstance().recipeUtil.getRecipesFromType(type)
-				: Main.getInstance().recipeUtil.getAllRecipes();
+				? Main.getInstance().getRecipeUtil().getRecipesFromType(type)
+				: Main.getInstance().getRecipeUtil().getAllRecipes();
 
 		if (recipesMap == null || recipesMap.isEmpty())
 			return new ArrayList<>();
@@ -160,7 +160,7 @@ public class BookGUI implements Listener {
 
 	public void showCreationMenu(Player player, Recipe rawRecipe, boolean creating, boolean viewing) {
 
-		RecipeGUI gui = Main.getInstance().editItem;
+		RecipeGUI gui = Main.getInstance().getEditItem();
 		Recipe recipe = rawRecipe;
 
 		if (creating) {
@@ -234,7 +234,7 @@ public class BookGUI implements Listener {
 				if (e.getCurrentItem() == null || e.getCurrentItem().getType() == Material.AIR)
 					return;
 
-				boolean isViewing = Main.getInstance().recipeBook.contains(p.getUniqueId());
+				boolean isViewing = Main.getInstance().getRecipeBook().contains(p.getUniqueId());
 
 				ItemStack stained = createItem("stainedG", XMaterial.BLACK_STAINED_GLASS_PANE, " ");
 				if (!e.getCurrentItem().equals(stained) && (e.getRawSlot() == 3 || e.getRawSlot() == 5)) {
@@ -245,7 +245,7 @@ public class BookGUI implements Listener {
 				}
 
 				if (e.getRawSlot() == 49) {
-					Main.getInstance().typeGUI.open(p);
+					Main.getInstance().getTypeGUI().open(p);
 					return;
 				}
 
@@ -358,7 +358,7 @@ public class BookGUI implements Listener {
 				getParsedValue("Buttons.Main-Menu", "&eMain Menu"));
 		ItemStack limestained = null;
 
-		if (!Main.getInstance().recipeBook.contains(p.getUniqueId()))
+		if (!Main.getInstance().getRecipeBook().contains(p.getUniqueId()))
 			limestained = createItem("stainedG", XMaterial.LIME_STAINED_GLASS_PANE,
 					getParsedValue("Buttons.Create", "&2Create Recipe"));
 
@@ -414,7 +414,7 @@ public class BookGUI implements Listener {
 	}
 
 	public void openType(Player p, RecipeType type) {
-		boolean isViewing = Main.getInstance().recipeBook.contains(p.getUniqueId());
+		boolean isViewing = Main.getInstance().getRecipeBook().contains(p.getUniqueId());
 		List<RecipeUtil.Recipe> recipes = buildRecipesFor(p, type, isViewing);
 
 		if (recipes.isEmpty()) {
@@ -444,7 +444,7 @@ public class BookGUI implements Listener {
 	}
 
 	void logDebug(String st) {
-		if (Main.getInstance().debug)
+		if (Main.getInstance().isDebug())
 			Logger.getLogger("Minecraft").log(Level.WARNING, "[DEBUG][" + Main.getInstance().getName() + "] " + st);
 	}
 

--- a/src/me/mehboss/gui/RecipeSaver.java
+++ b/src/me/mehboss/gui/RecipeSaver.java
@@ -649,11 +649,11 @@ public class RecipeSaver {
 	}
 
 	RecipeBuilder getRecipeBuilder() {
-		return Main.getInstance().recipeBuilder;
+		return Main.getInstance().getRecipeBuilder();
 	}
 
 	RecipeUtil getRecipeUtil() {
-		return Main.getInstance().recipeUtil;
+		return Main.getInstance().getRecipeUtil();
 	}
 
 	FileConfiguration getConfig() {

--- a/src/me/mehboss/gui/RecipeTypeGUI.java
+++ b/src/me/mehboss/gui/RecipeTypeGUI.java
@@ -118,5 +118,5 @@ public class RecipeTypeGUI implements Listener {
 		BookGUI.openType(p, type); // send to BookGUI to show recipes of this type
 	}
 
-	BookGUI BookGUI = Main.getInstance().recipes;
+	BookGUI BookGUI = Main.getInstance().getBookGUI();
 }

--- a/src/me/mehboss/gui/RecipeViewBuilder.java
+++ b/src/me/mehboss/gui/RecipeViewBuilder.java
@@ -154,11 +154,11 @@ public class RecipeViewBuilder {
 		ItemStack base = null;
 
 		if (ing.hasIdentifier()) {
-			Recipe r = Main.getInstance().recipeUtil.getRecipeFromKey(ing.getIdentifier());
+			Recipe r = Main.getInstance().getRecipeUtil().getRecipeFromKey(ing.getIdentifier());
 			if (r != null)
 				base = r.getResult();
 			else
-				base = Main.getInstance().recipeUtil.getResultFromKey(ing.getIdentifier());
+				base = Main.getInstance().getRecipeUtil().getResultFromKey(ing.getIdentifier());
 		} else if (ing.hasItem()) {
 			base = ing.getItem();
 		} else {

--- a/src/me/mehboss/gui/framework/GuiView.java
+++ b/src/me/mehboss/gui/framework/GuiView.java
@@ -65,7 +65,7 @@ public class GuiView {
 	 * click opened another recipe.
 	 */
 	public void handleRecipeClick(Player player, InventoryClickEvent e) {
-		Main.getInstance().editItem.handleRecipeLinkClick(player, e.getCurrentItem());
+		Main.getInstance().getEditItem().handleRecipeLinkClick(player, e.getCurrentItem());
 	}
 
 	public boolean onRawClick(Player player, InventoryClickEvent e) {

--- a/src/me/mehboss/gui/framework/RecipeGUI.java
+++ b/src/me/mehboss/gui/framework/RecipeGUI.java
@@ -53,7 +53,7 @@ public class RecipeGUI {
 			String key = nbt.getString("CUSTOM_ITEM_IDENTIFIER");
 			linked = Main.getInstance().getRecipeUtil().getRecipeFromKey(key);
 		} else {
-			linked = Main.getInstance().recipeUtil.getRecipeFromResult(clickedItem);
+			linked = Main.getInstance().getRecipeUtil().getRecipeFromResult(clickedItem);
 		}
 
 		if (linked == null)
@@ -88,11 +88,11 @@ public class RecipeGUI {
 				if (root != null && root != view) {
 					root.open(player);
 				} else {
-					List<Recipe> types = Main.getInstance().recipes.buildRecipesFor(p, recipe.getType(), true);
-					if (types == null || types.isEmpty()) {
-						Main.getInstance().typeGUI.open(p);
-					} else {
-						Main.getInstance().recipes.openType(p, recipe.getType());
+List<Recipe> types = Main.getInstance().getBookGUI().buildRecipesFor(p, recipe.getType(), true);
+				if (types == null || types.isEmpty()) {
+					Main.getInstance().getTypeGUI().open(p);
+				} else {
+					Main.getInstance().getBookGUI().openType(p, recipe.getType());
 					}
 
 					GuiRegistry.clearRootView(player.getUniqueId());
@@ -131,11 +131,11 @@ public class RecipeGUI {
 		/* -------- Main Menu (slot 49) -------- */
 		overrideOn(view, 49, (p, v, e) -> {
 			p.closeInventory();
-			List<Recipe> types = Main.getInstance().recipes.buildRecipesFor(p, recipe.getType(), false);
+			List<Recipe> types = Main.getInstance().getBookGUI().buildRecipesFor(p, recipe.getType(), false);
 			if (types == null || types.isEmpty()) {
-				Main.getInstance().typeGUI.open(p);
+				Main.getInstance().getTypeGUI().open(p);
 			} else {
-				Main.getInstance().recipes.openType(p, recipe.getType());
+				Main.getInstance().getBookGUI().openType(p, recipe.getType());
 			}
 		});
 	}
@@ -177,7 +177,7 @@ public class RecipeGUI {
 			}
 
 			player.closeInventory();
-			Main.getInstance().typeGUI.open(player);
+			Main.getInstance().getTypeGUI().open(player);
 		};
 	}
 

--- a/src/me/mehboss/listeners/AutoDiscover.java
+++ b/src/me/mehboss/listeners/AutoDiscover.java
@@ -78,7 +78,7 @@ public class AutoDiscover implements Listener {
 	}
 	
 	RecipeUtil getRecipeUtil() {
-		return Main.getInstance().recipeUtil;
+		return Main.getInstance().getRecipeUtil();
 	}
 	
 	Main instance() {

--- a/src/me/mehboss/listeners/BlockManager.java
+++ b/src/me/mehboss/listeners/BlockManager.java
@@ -20,7 +20,9 @@ import me.mehboss.utils.RecipeUtil.Recipe;
 
 public class BlockManager implements Listener {
 
-	RecipeUtil recipeUtil = Main.getInstance().getRecipeUtil();
+	RecipeUtil recipeUtil() {
+		return Main.getInstance().getRecipeUtil();
+	}
 
 	@EventHandler
 	public void onPlace(BlockPlaceEvent e) {
@@ -33,16 +35,16 @@ public class BlockManager implements Listener {
 		ItemStack item = e.getItemInHand();
 		ReadWriteNBT nbt = NBT.itemStackToNBT(item);
 
-		if (item.getType() != Material.AIR && item.hasItemMeta() && nbt.hasTag("CUSTOM_ITEM_IDENTIFER")) {
+		if (item.getType() != Material.AIR && item.hasItemMeta() && nbt.hasTag("CUSTOM_ITEM_IDENTIFIER")) {
 			key = nbt.getString("CUSTOM_ITEM_IDENTIFIER");
 		}
 
-		if (key != null && recipeUtil.getRecipeFromKey(key) != null)
-			recipe = recipeUtil.getRecipeFromKey(key);
+		if (key != null && recipeUtil().getRecipeFromKey(key) != null)
+			recipe = recipeUtil().getRecipeFromKey(key);
 
 		if (recipe == null)
-			if (recipeUtil.getRecipeFromResult(item) != null) {
-				recipe = recipeUtil.getRecipeFromResult(item);
+			if (recipeUtil().getRecipeFromResult(item) != null) {
+				recipe = recipeUtil().getRecipeFromResult(item);
 			}
 
 		if (recipe == null || recipe.isPlaceable())

--- a/src/me/mehboss/listeners/EffectsManager.java
+++ b/src/me/mehboss/listeners/EffectsManager.java
@@ -1,6 +1,8 @@
 package me.mehboss.listeners;
 
 import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.bukkit.Material;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -21,21 +23,34 @@ import de.tr7zw.changeme.nbtapi.NBT;
 import de.tr7zw.changeme.nbtapi.iface.ReadWriteNBT;
 import me.mehboss.recipe.Main;
 import me.mehboss.utils.RecipeUtil;
+import me.mehboss.utils.RecipeUtil.Recipe;
 
 public class EffectsManager implements Listener {
 
-	FileConfiguration getConfig(String recipeName) {
-		File dataFolder = Main.getInstance().getDataFolder();
-		File recipesFolder = new File(dataFolder, "recipes");
-		File recipeFile = new File(recipesFolder, recipeName + ".yml");
+	private final Map<String, FileConfiguration> configCache = new HashMap<>();
 
+	/** Limpia el caché de configuraciones al hacer /crecipe reload */
+	public void invalidateConfigCache() {
+		configCache.clear();
+	}
+
+	FileConfiguration getConfig(String recipeName) {
+		FileConfiguration cached = configCache.get(recipeName);
+		if (cached != null)
+			return cached;
+
+		File recipeFile = new File(new File(Main.getInstance().getDataFolder(), "recipes"), recipeName + ".yml");
 		if (!recipeFile.exists())
 			return null;
 
-		return YamlConfiguration.loadConfiguration(recipeFile);
+		FileConfiguration config = YamlConfiguration.loadConfiguration(recipeFile);
+		configCache.put(recipeName, config);
+		return config;
 	}
 
-	RecipeUtil recipeUtil = Main.getInstance().getRecipeUtil();
+	RecipeUtil recipeUtil() {
+		return Main.getInstance().getRecipeUtil();
+	}
 
 	@SuppressWarnings("deprecation")
 	@EventHandler
@@ -64,14 +79,16 @@ public class EffectsManager implements Listener {
 			String configName = null;
 
 			ReadWriteNBT nbt = NBT.itemStackToNBT(item);
-			if (nbt.hasTag("CUSTOM_ITEM_IDENTIFER"))
+			if (nbt.hasTag("CUSTOM_ITEM_IDENTIFIER"))
 				identifier = nbt.getString("CUSTOM_ITEM_IDENTIFIER");
 
-			if (identifier != null && recipeUtil.getRecipeFromKey(identifier) != null)
-				foundItem = recipeUtil.getRecipeFromKey(identifier).getResult();
-
-			if (foundItem != null && recipeUtil.getRecipeFromKey(identifier) != null)
-				configName = recipeUtil.getRecipeFromKey(identifier).getName();
+			if (identifier != null) {
+				Recipe found = recipeUtil().getRecipeFromKey(identifier);
+				if (found != null) {
+					foundItem = found.getResult();
+					configName = found.getName();
+				}
+			}
 
 			if (configName == null || foundItem == null || identifier == null || getConfig(configName) == null)
 				return;
@@ -81,10 +98,16 @@ public class EffectsManager implements Listener {
 
 				for (String e : getConfig(configName).getStringList(configName + ".Effects")) {
 
+					if (e == null || e.isEmpty())
+						continue;
+
 					String[] effectSplit = e.split(":");
+					if (effectSplit.length < 3)
+						continue;
+
 					String eff = effectSplit[0].toUpperCase();
 
-					if (e == null || PotionEffectType.getByName(eff) == null)
+					if (PotionEffectType.getByName(eff) == null)
 						continue;
 
 					String dur = effectSplit[1];

--- a/src/me/mehboss/recipe/Blacklist.java
+++ b/src/me/mehboss/recipe/Blacklist.java
@@ -45,13 +45,13 @@ public class Blacklist {
 		blacklistedLegacyResults.clear();
 		disableAllVanilla = false;
 
-		if (instance().customConfig == null)
+		if (instance().getCustomConfig() == null)
 			return;
 
 		boolean modern = instance().serverVersionAtLeast(1, 16);
 
-		if (instance().customConfig.isConfigurationSection("override-recipes")) {
-			ConfigurationSection sec = instance().customConfig.getConfigurationSection("override-recipes");
+		if (instance().getCustomConfig().isConfigurationSection("override-recipes")) {
+			ConfigurationSection sec = instance().getCustomConfig().getConfigurationSection("override-recipes");
 
 			if (modern) {
 				removeRecipesModern(sec);
@@ -60,7 +60,7 @@ public class Blacklist {
 			}
 		}
 
-		disableAllVanilla = instance().customConfig.getBoolean("disable-all-vanilla", false);
+		disableAllVanilla = instance().getCustomConfig().getBoolean("disable-all-vanilla", false);
 	}
 
 	// --- Modern recipe removal (1.16+) ---
@@ -189,15 +189,15 @@ public class Blacklist {
 	}
 
 	FileConfiguration getBlacklistConfig() {
-		return Main.getInstance().customConfig;
+		return Main.getInstance().getCustomConfig();
 	}
 
 	RecipeUtil getRecipeUtil() {
-		return Main.getInstance().recipeUtil;
+		return Main.getInstance().getRecipeUtil();
 	}
 
 	ArrayList<String> getDisabledRecipes() {
-		return Main.getInstance().disabledrecipe;
+		return Main.getInstance().getDisabledRecipes();
 	}
 
 	public void logError(String st) {
@@ -205,7 +205,7 @@ public class Blacklist {
 	}
 
 	public void logDebug(String st) {
-		if (instance().debug)
+		if (instance().isDebug())
 			Logger.getLogger("Minecraft").log(Level.WARNING, "[DEBUG][" + Main.getInstance().getName() + "]" + st);
 	}
 }

--- a/src/me/mehboss/recipe/ExactChoice.java
+++ b/src/me/mehboss/recipe/ExactChoice.java
@@ -35,11 +35,11 @@ import me.mehboss.utils.libs.CompatibilityUtil;
 public class ExactChoice {
 
 	RecipeBuilder getRecipeBuilder() {
-		return Main.getInstance().recipeBuilder;
+		return Main.getInstance().getRecipeBuilder();
 	}
 
 	RecipeUtil getRecipeUtil() {
-		return Main.getInstance().recipeUtil;
+		return Main.getInstance().getRecipeUtil();
 	}
 
 	RecipeChoice.ExactChoice returnExactChoice(ItemStack item) {
@@ -262,8 +262,20 @@ public class ExactChoice {
 					returnExactChoice(recipe.getAddition()));
 		}
 		return new SmithingTransformRecipe(new NamespacedKey(Main.getInstance(), recipe.getKey()), recipe.getResult(),
-				returnExactChoice(recipe.getTemplate()), returnExactChoice(recipe.getBase()),
-				returnExactChoice(recipe.getAddition()));
+				getSmithingIngredientChoice(recipe.getTemplateIngredient(), recipe.getTemplate()),
+				getSmithingIngredientChoice(recipe.getBaseIngredient(), recipe.getBase()),
+				getSmithingIngredientChoice(recipe.getAdditionIngredient(), recipe.getAddition()));
+	}
+
+	/**
+	 * Always returns a MaterialChoice so Bukkit only filters by material type.
+	 * Full ingredient verification (identifier, name, CMD, lore, itemModel, Nexo/MM/EI keys)
+	 * is delegated to passesChecks() → MetaChecks.itemsMatch(), which runs after
+	 * the Bukkit test passes. This allows enchanted/reforged bases and custom items
+	 * (Nexo, etc.) to pass the Bukkit layer correctly.
+	 */
+	private RecipeChoice getSmithingIngredientChoice(Ingredient ingredient, ItemStack item) {
+		return new RecipeChoice.MaterialChoice(item.getType());
 	}
 
 	private void logError(String st, String recipe) {
@@ -272,7 +284,7 @@ public class ExactChoice {
 	}
 
 	private void logDebug(String st, String recipe) {
-		if (Main.getInstance().debug)
+		if (Main.getInstance().isDebug())
 			Logger.getLogger("Minecraft").log(Level.WARNING,
 					"[DEBUG][" + Main.getInstance().getName() + "][" + recipe + "][EC] " + st);
 	}

--- a/src/me/mehboss/recipe/Main.java
+++ b/src/me/mehboss/recipe/Main.java
@@ -10,7 +10,6 @@ import java.util.concurrent.Callable;
 import java.util.logging.Level;
 
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.command.PluginCommand;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -48,32 +47,39 @@ import me.mehboss.utils.libs.ItemManager;
 import me.mehboss.utils.libs.ItemFactory;
 import me.mehboss.utils.libs.MetaChecks;
 import me.mehboss.utils.libs.CooldownManager.Cooldown;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.TextComponent;
+import org.bukkit.event.HandlerList;
 
 public class Main extends JavaPlugin implements Listener {
 
-	public RecipeUtil recipeUtil;
-	public RecipeBuilder recipeBuilder;
-	public ExactChoice exactChoice;
+	private RecipeUtil recipeUtil;
+	private RecipeBuilder recipeBuilder;
+	private ExactChoice exactChoice;
 
-	public AmountManager amountManager;
-	public CraftManager craftManager;
+	private AmountManager amountManager;
+	private CraftManager craftManager;
 
-	public ShapedChecks shapedChecks;
-	public ShapelessChecks shapelessChecks;
+	private ShapedChecks shapedChecks;
+	private ShapelessChecks shapelessChecks;
 
-	public ItemFactory itemFactory;
-	public MetaChecks metaChecks;
+	private ItemFactory itemFactory;
+	private MetaChecks metaChecks;
 
-	public BookGUI recipes;
-	public RecipeTypeGUI typeGUI;
-	public CooldownManager cooldownManager;
+	private BookGUI recipes;
+	private RecipeTypeGUI typeGUI;
+	private CooldownManager cooldownManager;
 
 	private AutoDiscover autoDiscover;
+	private EffectsManager effectsManager;
 
 	public AutoDiscover getAutoDiscover() {
 		return autoDiscover;
+	}
+
+	public EffectsManager getEffectsManager() {
+		return effectsManager;
 	}
 
 	private Blacklist handleBlacklist;
@@ -82,16 +88,16 @@ public class Main extends JavaPlugin implements Listener {
 		return handleBlacklist;
 	}
 
-	public RecipeGUI editItem;
+	private RecipeGUI editItem;
 
-	public Map<UUID, Long> debounceMap = new HashMap<>();
-	public ArrayList<UUID> inInventory = new ArrayList<UUID>();
-	public ArrayList<UUID> recipeBook = new ArrayList<UUID>();
-	public ArrayList<String> disabledrecipe = new ArrayList<String>();
+	private Map<UUID, Long> debounceMap = new HashMap<>();
+	private ArrayList<UUID> inInventory = new ArrayList<UUID>();
+	private ArrayList<UUID> recipeBook = new ArrayList<UUID>();
+	private ArrayList<String> disabledrecipe = new ArrayList<String>();
 
 	// add three more shapelessname, amount, and ID specifically for config.
 
-	public FileConfiguration customConfig = null;
+	private FileConfiguration customConfig = null;
 	File customYml = new File(getDataFolder() + "/blacklisted.yml");
 
 	FileConfiguration cooldownConfig = null;
@@ -103,13 +109,10 @@ public class Main extends JavaPlugin implements Listener {
 	File bagYml = new File(getDataFolder() + "/recipes/HavenBag.yml");
 	File sandYml = new File(getDataFolder() + "/recipes/WheatSand.yml");
 
-	public Boolean debug = false;
-	public Boolean crafterdebug = false;
+	private boolean debug = false;
+	private boolean crafterdebug = false;
 
-	public Boolean hasAE = false;
-	public Boolean hasEE = false;
-	public Boolean hasHavenBags = false;
-	public Boolean hasEEnchants = false;
+	private boolean hasEE = false;
 
 	Boolean uptodate = true;
 	Boolean isFirstLoad = true;
@@ -125,20 +128,37 @@ public class Main extends JavaPlugin implements Listener {
 		return recipeUtil;
 	}
 
+	public RecipeBuilder getRecipeBuilder() { return recipeBuilder; }
+	public ExactChoice getExactChoice() { return exactChoice; }
+	public AmountManager getAmountManager() { return amountManager; }
+	public CraftManager getCraftManager() { return craftManager; }
+	public ShapedChecks getShapedChecks() { return shapedChecks; }
+	public ShapelessChecks getShapelessChecks() { return shapelessChecks; }
+	public ItemFactory getItemFactory() { return itemFactory; }
+	public MetaChecks getMetaChecks() { return metaChecks; }
+	public BookGUI getBookGUI() { return recipes; }
+	public RecipeTypeGUI getTypeGUI() { return typeGUI; }
+	public CooldownManager getCooldownManager() { return cooldownManager; }
+	public RecipeGUI getEditItem() { return editItem; }
+	public Map<UUID, Long> getDebounceMap() { return debounceMap; }
+	public ArrayList<UUID> getInInventory() { return inInventory; }
+	public ArrayList<UUID> getRecipeBook() { return recipeBook; }
+	public ArrayList<String> getDisabledRecipes() { return disabledrecipe; }
+	public FileConfiguration getCustomConfig() { return customConfig; }
+	public boolean isDebug() { return debug; }
+	public void setDebug(boolean value) { debug = value; }
+	public boolean isCrafterDebug() { return crafterdebug; }
+	public void setCrafterDebug(boolean value) { crafterdebug = value; }
+	public boolean isHasEE() { return hasEE; }
+
 	public boolean hasCustomPlugin(String plugin) {
 		switch (plugin) {
-		case "itemsadder":
-			return Bukkit.getPluginManager().getPlugin("ItemsAdder") != null;
 		case "mythicmobs":
 			return Bukkit.getPluginManager().getPlugin("MythicMobs") != null && serverVersionAtLeast(1, 16);
 		case "executableitems":
 			return Bukkit.getPluginManager().getPlugin("ExecutableItems") != null;
 		case "nexo":
 			return Bukkit.getPluginManager().getPlugin("Nexo") != null;
-		case "oraxen":
-			return Bukkit.getPluginManager().getPlugin("Oraxen") != null;
-		case "mmoitems":
-			return Bukkit.getPluginManager().getPlugin("MMOItems") != null;
 		}
 		return false;
 	}
@@ -236,6 +256,8 @@ public class Main extends JavaPlugin implements Listener {
 
 		// Get all files in the "recipes" folder
 		File[] recipeFiles = recipesFolder.listFiles();
+		if (recipeFiles == null)
+			return;
 		for (File recipeFile : recipeFiles) {
 			if (recipeFile.isFile()) {
 				String fileName = recipeFile.getName();
@@ -270,15 +292,8 @@ public class Main extends JavaPlugin implements Listener {
 
 		if (Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null)
 			new Placeholders().register();
-		if (Bukkit.getPluginManager().getPlugin("AdvancedEnchantments") != null)
-			hasAE = true;
 		if (Bukkit.getPluginManager().getPlugin("EcoEnchants") != null)
 			hasEE = true;
-		if (Bukkit.getPluginManager().getPlugin("ExcellentEnchants") != null)
-			hasEEnchants = true;
-		if (Bukkit.getPluginManager().getPlugin("HavenBags") != null) {
-			hasHavenBags = true;
-		}
 
 		getLogger().log(Level.INFO,
 				"Made by MehBoss on Spigot. For support please PM me and I will get back to you as soon as possible!");
@@ -328,7 +343,8 @@ public class Main extends JavaPlugin implements Listener {
 		Bukkit.getPluginManager().registerEvents(new GuiListener(), this);
 		Bukkit.getPluginManager().registerEvents(recipes, this);
 		Bukkit.getPluginManager().registerEvents(typeGUI, this);
-		Bukkit.getPluginManager().registerEvents(new EffectsManager(), this);
+		effectsManager = new EffectsManager();
+		Bukkit.getPluginManager().registerEvents(effectsManager, this);
 		Bukkit.getPluginManager().registerEvents(craftManager, this);
 		Bukkit.getPluginManager().registerEvents(amountManager, this);
 		Bukkit.getPluginManager().registerEvents(new BlockManager(), this);
@@ -404,6 +420,8 @@ public class Main extends JavaPlugin implements Listener {
 
 		// Re-add recipes immediately
 		ItemManager.reload();
+		if (effectsManager != null)
+			effectsManager.invalidateConfigCache();
 		recipeBuilder.addRecipes(null);
 		getLogger().log(Level.INFO, "Reloaded " + recipeUtil.getRecipeNames().size() + " recipe(s).");
 
@@ -412,6 +430,9 @@ public class Main extends JavaPlugin implements Listener {
 
 	@Override
 	public void onDisable() {
+
+		HandlerList.unregisterAll((org.bukkit.plugin.Plugin) this);
+		Bukkit.getScheduler().cancelTasks(this);
 
 		if (cooldownManager != null) {
 
@@ -442,6 +463,7 @@ public class Main extends JavaPlugin implements Listener {
 			saveCustomYml(cooldownConfig, cooldownYml);
 		}
 		clear();
+		instance = null;
 	}
 
 	void addCooldowns() {
@@ -482,16 +504,14 @@ public class Main extends JavaPlugin implements Listener {
 		long minutes = (totalSeconds % 3600) / 60; // Calculate minutes
 		long seconds = totalSeconds % 60; // Calculate remaining seconds
 
-		// Configurable message template
-		String messageTemplate = ChatColor.translateAlternateColorCodes('&',
-				customConfig.getString("crafting-limit.chat-message.message"));
+		// Configurable message template (& codes handled by LegacyComponentSerializer at call site)
+		String messageTemplate = customConfig.getString("crafting-limit.chat-message.message", "");
 
-		// Replace placeholders with actual values
-		String message = ChatColor.translateAlternateColorCodes('&',
-				messageTemplate.replace("%days%", String.valueOf(days)).replace("%hours%", String.valueOf(hours))
-						.replace("%minutes%", String.valueOf(minutes)).replace("%seconds%", String.valueOf(seconds)));
-
-		return message;
+		return messageTemplate
+				.replace("%days%", String.valueOf(days))
+				.replace("%hours%", String.valueOf(hours))
+				.replace("%minutes%", String.valueOf(minutes))
+				.replace("%seconds%", String.valueOf(seconds));
 	}
 
 	public void sendMessage(Player player, String basePath, long seconds) {
@@ -499,10 +519,10 @@ public class Main extends JavaPlugin implements Listener {
 		// ACTION BAR
 		if (customConfig.getBoolean(basePath + ".actionbar-message.enabled")) {
 			try {
-				String message = ChatColor.translateAlternateColorCodes('&',
-						customConfig.getString(basePath + ".actionbar-message.message", ""));
-
-				player.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(message));
+				String raw = customConfig.getString(basePath + ".actionbar-message.message", "");
+				String rendered = LegacyComponentSerializer.legacySection().serialize(
+						LegacyComponentSerializer.legacyAmpersand().deserialize(raw));
+				player.spigot().sendMessage(ChatMessageType.ACTION_BAR, new TextComponent(rendered));
 			} catch (Exception e) {
 				getLogger().log(Level.SEVERE, "Error while sending action bar message", e);
 			}
@@ -510,16 +530,18 @@ public class Main extends JavaPlugin implements Listener {
 
 		// CHAT MESSAGE
 		if (customConfig.getBoolean(basePath + ".chat-message.enabled")) {
-			String message;
+			String rendered;
 
 			if (basePath.equalsIgnoreCase("crafting-limit")) {
-				message = getCooldownMessage(seconds);
+				rendered = LegacyComponentSerializer.legacySection().serialize(
+						LegacyComponentSerializer.legacyAmpersand().deserialize(getCooldownMessage(seconds)));
 			} else {
-				message = ChatColor.translateAlternateColorCodes('&',
-						customConfig.getString(basePath + ".chat-message.message", ""));
+				rendered = LegacyComponentSerializer.legacySection().serialize(
+						LegacyComponentSerializer.legacyAmpersand().deserialize(
+								customConfig.getString(basePath + ".chat-message.message", "")));
 			}
 
-			player.sendMessage(message);
+			player.sendMessage(rendered);
 		}
 
 		// CLOSE INVENTORY
@@ -534,10 +556,12 @@ public class Main extends JavaPlugin implements Listener {
 
 		// Update check
 		if (getConfig().getBoolean("Update-Check") && p.hasPermission("crecipe.reload")
-				&& getDescription().getVersion().compareTo(newupdate) < 0) {
-			p.sendMessage(ChatColor.translateAlternateColorCodes('&',
-					"&cCustom-Recipes: &fAn update has been found. Please download version&c " + newupdate
-							+ ", &fyou are on version&c " + getDescription().getVersion() + "!"));
+				&& newupdate != null && getDescription().getVersion().compareTo(newupdate) < 0) {
+			String rendered = LegacyComponentSerializer.legacySection().serialize(
+					LegacyComponentSerializer.legacyAmpersand().deserialize(
+							"&cCustom-Recipes: &fAn update has been found. Please download version&c " + newupdate
+									+ ", &fyou are on version&c " + getDescription().getVersion() + "!"));
+			p.sendMessage(rendered);
 		}
 	}
 

--- a/src/me/mehboss/recipe/Main.java
+++ b/src/me/mehboss/recipe/Main.java
@@ -16,7 +16,9 @@ import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.CraftItemEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.plugin.RegisteredListener;
 import org.bukkit.plugin.java.JavaPlugin;
 import me.mehboss.anvil.AnvilManager;
 import me.mehboss.anvil.AnvilManager_1_8;
@@ -351,6 +353,8 @@ public class Main extends JavaPlugin implements Listener {
 		Bukkit.getPluginManager().registerEvents(new CookingManager(), this);
 		Bukkit.getPluginManager().registerEvents(new BrewEvent(), this);
 		Bukkit.getPluginManager().registerEvents(this, this);
+		getLogger().warning("[DEBUG-ITEMREMOVAL] Registered AmountManager listener instance: "
+				+ amountManager.getClass().getName());
 
 		if (serverVersionAtLeast(1, 21)) {
 			Bukkit.getPluginManager().registerEvents(new CrafterManager(), this);
@@ -373,6 +377,32 @@ public class Main extends JavaPlugin implements Listener {
 
 		registerUpdateChecker();
 		registerBstats();
+
+		Bukkit.getScheduler().runTaskLater(this, () -> {
+			boolean foundAmountManagerListener = false;
+
+			for (RegisteredListener rl : HandlerList.getRegisteredListeners(this)) {
+				Listener listener = rl.getListener();
+				if (listener == null)
+					continue;
+
+				String listenerClass = listener.getClass().getName();
+				if (listenerClass.endsWith("AmountManager")) {
+					foundAmountManagerListener = true;
+					getLogger().warning("[DEBUG-ITEMREMOVAL] Found registered listener: " + listenerClass + " @ "
+							+ rl.getPriority());
+				}
+			}
+
+			int ownCraftItemCount = 0;
+			for (RegisteredListener rl : CraftItemEvent.getHandlerList().getRegisteredListeners()) {
+				if (rl.getPlugin() == this)
+					ownCraftItemCount++;
+			}
+
+			getLogger().warning("[DEBUG-ITEMREMOVAL] CraftItemEvent listeners for this plugin: " + ownCraftItemCount
+					+ " | AmountManager registered: " + foundAmountManagerListener);
+		}, 1L);
 	}
 
 	public void clear() {

--- a/src/me/mehboss/recipe/RecipeBuilder.java
+++ b/src/me/mehboss/recipe/RecipeBuilder.java
@@ -59,11 +59,11 @@ public class RecipeBuilder {
 	FileConfiguration recipeConfig = null;
 
 	RecipeUtil getRecipeUtil() {
-		return Main.getInstance().recipeUtil;
+		return Main.getInstance().getRecipeUtil();
 	}
 
 	ItemFactory getItemFactory() {
-		return Main.getInstance().itemFactory;
+		return Main.getInstance().getItemFactory();
 	}
 
 	FileConfiguration getConfig() {
@@ -211,9 +211,9 @@ public class RecipeBuilder {
 
 		SmithingRecipeType type = SmithingRecipeType.fromString(getConfig().getString(configPath + ".Type"));
 		smithing.setSmithingType(type);
-		boolean copyTrim = getConfig().getBoolean(configPath + ".Copy-Trim");
+		boolean copyTrim = getConfig().getBoolean(configPath + ".Copy-Trim", true);
 		smithing.setCopyTrim(copyTrim);
-		boolean copyEnchants = getConfig().getBoolean(configPath + ".Copy-Enchants");
+		boolean copyEnchants = getConfig().getBoolean(configPath + ".Copy-Enchants", true);
 		smithing.setCopyEnchants(copyEnchants);
 	}
 
@@ -584,7 +584,7 @@ public class RecipeBuilder {
 	}
 
 	public void addRecipesFromAPI(Recipe specificRecipe) {
-		RecipeUtil recipeUtil = Main.getInstance().recipeUtil;
+		RecipeUtil recipeUtil = Main.getInstance().getRecipeUtil();
 		HashMap<String, Recipe> recipeList = recipeUtil.getAllRecipes() == null ? null
 				: new HashMap<>(recipeUtil.getAllRecipes());
 
@@ -612,7 +612,7 @@ public class RecipeBuilder {
 				switch (recipe.getType()) {
 				case SHAPELESS:
 					if (Main.getInstance().serverVersionAtLeast(1, 13, 2)) {
-						shapelessRecipe = Main.getInstance().exactChoice
+						shapelessRecipe = Main.getInstance().getExactChoice()
 								.createShapelessRecipe((CraftingRecipeData) recipe);
 						break;
 					}
@@ -622,7 +622,7 @@ public class RecipeBuilder {
 
 				case SHAPED:
 					if (Main.getInstance().serverVersionAtLeast(1, 13, 2)) {
-						shapedRecipe = Main.getInstance().exactChoice.createShapedRecipe((CraftingRecipeData) recipe);
+						shapedRecipe = Main.getInstance().getExactChoice().createShapedRecipe((CraftingRecipeData) recipe);
 						break;
 					}
 
@@ -631,7 +631,7 @@ public class RecipeBuilder {
 
 				case FURNACE:
 					if (Main.getInstance().serverVersionAtLeast(1, 13, 2)) {
-						furnaceRecipe = Main.getInstance().exactChoice.createFurnaceRecipe((CookingRecipeData) recipe);
+						furnaceRecipe = Main.getInstance().getExactChoice().createFurnaceRecipe((CookingRecipeData) recipe);
 						break;
 					}
 
@@ -640,27 +640,27 @@ public class RecipeBuilder {
 
 				case BLASTFURNACE:
 					if (Main.getInstance().serverVersionAtLeast(1, 13, 2)) {
-						blastRecipe = Main.getInstance().exactChoice
+							blastRecipe = Main.getInstance().getExactChoice()
 								.createBlastFurnaceRecipe((CookingRecipeData) recipe);
 					}
 					break;
 
 				case SMOKER:
 					if (Main.getInstance().serverVersionAtLeast(1, 13, 2)) {
-						smokerRecipe = Main.getInstance().exactChoice.createSmokerRecipe((CookingRecipeData) recipe);
+						smokerRecipe = Main.getInstance().getExactChoice().createSmokerRecipe((CookingRecipeData) recipe);
 					}
 					break;
 
 				case STONECUTTER:
 					if (Main.getInstance().serverVersionAtLeast(1, 13, 2)) {
-						sCutterRecipe = Main.getInstance().exactChoice
+							sCutterRecipe = Main.getInstance().getExactChoice()
 								.createStonecuttingRecipe((WorkstationRecipeData) recipe);
 					}
 					break;
 
 				case CAMPFIRE:
 					if (Main.getInstance().serverVersionAtLeast(1, 13, 2)) {
-						campfireRecipe = Main.getInstance().exactChoice
+							campfireRecipe = Main.getInstance().getExactChoice()
 								.createCampfireRecipe((CookingRecipeData) recipe);
 					}
 					break;
@@ -674,7 +674,7 @@ public class RecipeBuilder {
 
 				case SMITHING:
 					if (Main.getInstance().serverVersionAtLeast(1, 20)) {
-						smithingRecipe = Main.getInstance().exactChoice
+							smithingRecipe = Main.getInstance().getExactChoice()
 								.createSmithingRecipe((SmithingRecipeData) recipe);
 					}
 				}
@@ -823,7 +823,7 @@ public class RecipeBuilder {
 	}
 
 	private void logDebug(String st, String recipe) {
-		if (Main.getInstance().debug)
+		if (Main.getInstance().isDebug())
 			Logger.getLogger("Minecraft").log(Level.WARNING,
 					"[DEBUG][" + Main.getInstance().getName() + "][" + recipe.replaceAll(".Result", "") + "] " + st);
 	}

--- a/src/me/mehboss/utils/Placeholders.java
+++ b/src/me/mehboss/utils/Placeholders.java
@@ -61,10 +61,10 @@ public class Placeholders extends PlaceholderExpansion {
 
 			int ingredient = Integer.parseInt(split[3]);
 
-			if (Main.getInstance().recipeUtil.getRecipe(recipe) == null)
+			if (Main.getInstance().getRecipeUtil().getRecipe(recipe) == null)
 				return null;
 
-			RecipeUtil recipeUtil = Main.getInstance().recipeUtil;
+			RecipeUtil recipeUtil = Main.getInstance().getRecipeUtil();
 			List<RecipeUtil.Ingredient> ingredients = recipeUtil.getRecipe(recipe).getIngredients();
 
 			return ingredients.get(ingredient).getDisplayName().replaceAll("false", "None");
@@ -75,10 +75,10 @@ public class Placeholders extends PlaceholderExpansion {
 			String recipe = split[0];
 			int ingredient = Integer.parseInt(split[3]);
 
-			if (Main.getInstance().recipeUtil.getRecipe(recipe) == null)
+			if (Main.getInstance().getRecipeUtil().getRecipe(recipe) == null)
 				return null;
 
-			RecipeUtil recipeUtil = Main.getInstance().recipeUtil;
+			RecipeUtil recipeUtil = Main.getInstance().getRecipeUtil();
 			List<RecipeUtil.Ingredient> ingredients = recipeUtil.getRecipe(recipe).getIngredients();
 
 			return String.valueOf(ingredients.get(ingredient).getAmount());
@@ -90,10 +90,10 @@ public class Placeholders extends PlaceholderExpansion {
 			String recipe = split[0];
 			int ingredient = Integer.parseInt(split[3]);
 
-			if (Main.getInstance().recipeUtil.getRecipe(recipe) == null)
+			if (Main.getInstance().getRecipeUtil().getRecipe(recipe) == null)
 				return null;
 
-			RecipeUtil recipeUtil = Main.getInstance().recipeUtil;
+			RecipeUtil recipeUtil = Main.getInstance().getRecipeUtil();
 			List<RecipeUtil.Ingredient> ingredients = recipeUtil.getRecipe(recipe).getIngredients();
 
 			return String.valueOf(ingredients.get(ingredient).getIdentifier());
@@ -105,10 +105,10 @@ public class Placeholders extends PlaceholderExpansion {
 			String recipe = split[0];
 			int ingredient = Integer.parseInt(split[2]);
 
-			if (Main.getInstance().recipeUtil.getRecipe(recipe) == null)
+			if (Main.getInstance().getRecipeUtil().getRecipe(recipe) == null)
 				return null;
 
-			RecipeUtil recipeUtil = Main.getInstance().recipeUtil;
+			RecipeUtil recipeUtil = Main.getInstance().getRecipeUtil();
 			List<RecipeUtil.Ingredient> ingredients = recipeUtil.getRecipe(recipe).getIngredients();
 
 			return ingredients.get(ingredient).getMaterial().toString();

--- a/src/me/mehboss/utils/RecipeUtil.java
+++ b/src/me/mehboss/utils/RecipeUtil.java
@@ -3,6 +3,7 @@ package me.mehboss.utils;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -31,19 +32,13 @@ import com.ssomar.score.api.executableitems.ExecutableItemsAPI;
 import com.ssomar.score.api.executableitems.config.ExecutableItemInterface;
 
 import de.tr7zw.changeme.nbtapi.NBT;
-import dev.lone.itemsadder.api.CustomStack;
 import io.lumine.mythic.bukkit.MythicBukkit;
-import io.th0rgal.oraxen.api.OraxenItems;
 import me.mehboss.recipe.Blacklist;
 import me.mehboss.recipe.Main;
 import me.mehboss.utils.RecipeUtil.Recipe.RecipeType;
 import me.mehboss.utils.data.CookingRecipeData;
 import me.mehboss.utils.libs.CompatibilityUtil;
 import me.mehboss.utils.libs.ItemManager;
-import net.Indyuce.mmoitems.MMOItems;
-// Temporarily commented out due to jitpack.io server error (521)
-// import valorless.havenbags.api.HavenBagsAPI;
-// import valorless.havenbags.datamodels.Data;
 
 /**
  * Utility manager and API entry point for creating, validating, and storing
@@ -101,8 +96,12 @@ public class RecipeUtil {
 	private HashMap<String, Recipe> recipes = new HashMap<>();
 	private ArrayList<String> keyList = new ArrayList<>();
 	private HashMap<String, ItemStack> custom_items = new HashMap<>();
-	public List<String> SUPPORTED_PLUGINS = Arrays.asList("itemsadder", "mythicmobs", "executableitems", "oraxen",
-			"nexo", "mmoitems", "havenbags");
+	public List<String> SUPPORTED_PLUGINS = Arrays.asList("mythicmobs", "executableitems", "nexo");
+
+	// Performance indexes — kept in sync with 'recipes' map
+	private final HashMap<String, Recipe> recipesByKey = new HashMap<>();
+	private final EnumMap<RecipeType, Map<String, Recipe>> recipesByType = new EnumMap<>(RecipeType.class);
+	private static final Set<String> CUSTOM_ITEM_PLUGIN_IDS = Set.of("mythicmobs", "nexo", "executableitems");
 
 	/**
 	 * Adds a finished Recipe object to the API
@@ -148,6 +147,9 @@ public class RecipeUtil {
 		recipes.put(recipe.getName(), recipe);
 		if (!keyList.contains(recipe.getKey()))
 			keyList.add(recipe.getKey());
+		if (recipe.getKey() != null)
+			recipesByKey.put(recipe.getKey().toLowerCase(), recipe);
+		recipesByType.computeIfAbsent(recipe.getType(), k -> new HashMap<>()).put(recipe.getName(), recipe);
 	}
 
 	/**
@@ -161,6 +163,11 @@ public class RecipeUtil {
 			clearDuplicates(recipe);
 			keyList.remove(recipe.getKey());
 			recipes.remove(recipeName);
+			if (recipe.getKey() != null)
+				recipesByKey.remove(recipe.getKey().toLowerCase());
+			Map<String, Recipe> typeMap = recipesByType.get(recipe.getType());
+			if (typeMap != null)
+				typeMap.remove(recipeName);
 		}
 	}
 
@@ -172,7 +179,7 @@ public class RecipeUtil {
 	 */
 	public void registerRecipe(Recipe recipe) {
 		this.clearDuplicates(recipe);
-		Main.getInstance().recipeBuilder.addRecipesFromAPI(recipe);
+		Main.getInstance().getRecipeBuilder().addRecipesFromAPI(recipe);
 	}
 
 	/**
@@ -181,7 +188,7 @@ public class RecipeUtil {
 	 */
 	public void reloadRecipes() {
 		this.clearDuplicates(null);
-		Main.getInstance().recipeBuilder.addRecipesFromAPI(null);
+		Main.getInstance().getRecipeBuilder().addRecipesFromAPI(null);
 	}
 
 	/**
@@ -220,15 +227,7 @@ public class RecipeUtil {
 	public Boolean isCustomItem(String key) {
 		if (key == null)
 			return false;
-
-		String pluginID = key.toLowerCase();
-		String[] plugins = { "mythicmobs", "itemsadder", "mmoitems", "oraxen", "nexo", "executableitems" };
-
-		for (String plugin : plugins)
-			if (plugin.equals(pluginID))
-				return true;
-
-		return false;
+		return CUSTOM_ITEM_PLUGIN_IDS.contains(key.toLowerCase());
 	}
 
 	/**
@@ -268,14 +267,6 @@ public class RecipeUtil {
 		}
 
 		switch (namespace) {
-		case "itemsadder":
-			if (Main.getInstance().hasCustomPlugin("itemsadder")) {
-				CustomStack iaItem = CustomStack.getInstance(itemId);
-				if (iaItem != null)
-					return iaItem.getItemStack();
-			}
-			break;
-
 		case "mythicmobs":
 			if (Main.getInstance().hasCustomPlugin("mythicmobs")) {
 				ItemStack mythicItem = MythicBukkit.inst().getItemManager().getItemStack(itemId);
@@ -290,66 +281,27 @@ public class RecipeUtil {
 						.getExecutableItem(itemId);
 				if (ei.isPresent()) {
 					if (custom_items.containsKey(itemId)) {
-						return custom_items.get(itemId);
+						return custom_items.get(itemId).clone();
 					} else {
 						ItemStack eiItem = ei.get().buildItem(1, Optional.empty());
 						custom_items.put(itemId, eiItem);
-						return eiItem;
+						return eiItem.clone();
 					}
 				}
 			}
 			break;
 
-		case "oraxen":
-			if (Main.getInstance().hasCustomPlugin("oraxen")) {
-				ItemStack oraxenItem = OraxenItems.exists(itemId) ? OraxenItems.getItemById(itemId).build() : null;
-				if (oraxenItem != null)
-					return oraxenItem;
-			}
-			break;
-
 		case "nexo":
 			if (Main.getInstance().hasCustomPlugin("nexo")) {
-				if (NexoItems.itemFromId(itemId) != null)
-					return NexoItems.itemFromId(itemId).build();
+				if (custom_items.containsKey(item))
+					return custom_items.get(item).clone();
+				if (NexoItems.itemFromId(itemId) != null) {
+					ItemStack nexoItem = NexoItems.itemFromId(itemId).build();
+					custom_items.put(item, nexoItem);
+					return nexoItem.clone();
+				}
 			}
 			break;
-
-		case "mmoitems":
-			if (split.length < 3) {
-				logError("Could not complete recipe because MMOItems must specify a type, which can not be found. Key: "
-						+ item, recipe);
-				return null;
-			}
-
-			if (Main.getInstance().hasCustomPlugin("mmoitems")) {
-				ItemStack mmoitem = MMOItems.plugin.getItem(MMOItems.plugin.getTypes().get(split[2].toUpperCase()),
-						itemId.toUpperCase());
-				if (mmoitem != null)
-					return mmoitem;
-			}
-			break;
-
-		case "havenbags":
-			boolean hasArgs = split.length >= 3;
-			Material bagMaterial = hasArgs && XMaterial.matchXMaterial(split[2]).isPresent()
-					? XMaterial.matchXMaterial(split[2]).get().get()
-					: null;
-			int size = !hasArgs || Integer.getInteger(split[1]) == null ? 1 : Integer.parseInt(split[1]);
-			int bagCMD = split.length < 4 || Integer.getInteger(split[3]) == null ? 0 : Integer.parseInt(split[3]);
-			String canBind = split.length >= 5 ? split[4] : "null";
-			String bagTexture = split.length >= 6 ? split[5] : "none";
-
-			if (!hasArgs || bagMaterial == null) {
-				logError("Could not complete recipe because HavenBags is missing either a material or bag size. Key: "
-						+ item, recipe);
-				return null;
-			}
-
-			// havenbags:size:material:customModelData:canBind:texture
-			ItemStack bagItem = Main.getInstance().itemFactory.handleBagCreation(bagMaterial, size, bagCMD, canBind,
-					bagTexture, null);
-			return bagItem;
 
 		}
 
@@ -396,14 +348,6 @@ public class RecipeUtil {
 			return allKeys;
 		}
 
-		if (Main.getInstance().hasCustomPlugin("itemsadder")) {
-			CustomStack ia = CustomStack.byItemStack(item);
-			if (ia != null) {
-				allKeys.add("itemsadder:" + ia.getId());
-				return allKeys;
-			}
-		}
-
 		if (Main.getInstance().hasCustomPlugin("mythicmobs")) {
 			String mythicId = MythicBukkit.inst().getItemManager().getMythicTypeFromItem(item);
 			if (mythicId != null) {
@@ -421,13 +365,6 @@ public class RecipeUtil {
 			}
 		}
 
-		if (Main.getInstance().hasCustomPlugin("oraxen")) {
-			if (OraxenItems.exists(item)) {
-				allKeys.add("oraxen:" + OraxenItems.getIdByItem(item));
-				return allKeys;
-			}
-		}
-
 		if (Main.getInstance().hasCustomPlugin("nexo")) {
 			if (NexoItems.idFromItem(item) != null) {
 				allKeys.add("nexo:" + NexoItems.idFromItem(item));
@@ -435,31 +372,6 @@ public class RecipeUtil {
 			}
 		}
 
-		if (Main.getInstance().hasCustomPlugin("mmoitems")) {
-			String id = MMOItems.getID(item);
-			String type = MMOItems.getTypeName(item);
-			if (id != null && type != null) {
-				allKeys.add("mmoitems:" + id + ":" + type);
-				return allKeys;
-			}
-		}
-
-		if (Main.getInstance().hasCustomPlugin("havenbags")) {
-			// Temporarily commented out due to jitpack.io server error (521) - will restore after upgrade
-			/*
-			Data bagData = HavenBagsAPI.getBagData(item);
-			if (bagData != null) {
-				Material material = bagData.getMaterial();
-				String texture = bagData.getTexture();
-				int modelData = bagData.getModeldata();
-				int size = bagData.getSize();
-
-				// havenbags:size:material:customModelData:texture
-				allKeys.add("havenbags:" + size + material + modelData + texture);
-				return allKeys;
-			}
-			*/
-		}
 		return allKeys;
 	}
 
@@ -470,16 +382,9 @@ public class RecipeUtil {
 	 * @return the Recipe that is found, can be null
 	 */
 	public Recipe getRecipeFromKey(String key) {
-		for (Recipe recipe : recipes.values()) {
-			String recipeTag = recipe.getKey();
-
-			if (key == null)
-				return null;
-
-			if (key.equalsIgnoreCase(recipeTag))
-				return recipe;
-		}
-		return null;
+		if (key == null)
+			return null;
+		return recipesByKey.get(key.toLowerCase());
 	}
 
 	/**
@@ -624,19 +529,10 @@ public class RecipeUtil {
 	 * @return the hashmap of recipes found, can be null
 	 */
 	public HashMap<String, Recipe> getRecipesFromType(RecipeType type) {
-		if (recipes.isEmpty())
+		Map<String, Recipe> found = recipesByType.get(type);
+		if (found == null || found.isEmpty())
 			return null;
-
-		HashMap<String, Recipe> foundRecipes = new HashMap<String, Recipe>();
-		for (Recipe recipe : recipes.values()) {
-			if (recipe.getType() == type)
-				foundRecipes.put(recipe.getName(), recipe);
-		}
-
-		if (foundRecipes.isEmpty())
-			return null;
-
-		return foundRecipes;
+		return new HashMap<>(found);
 	}
 
 	/**

--- a/src/me/mehboss/utils/RecipeUtil.java
+++ b/src/me/mehboss/utils/RecipeUtil.java
@@ -41,8 +41,9 @@ import me.mehboss.utils.data.CookingRecipeData;
 import me.mehboss.utils.libs.CompatibilityUtil;
 import me.mehboss.utils.libs.ItemManager;
 import net.Indyuce.mmoitems.MMOItems;
-import valorless.havenbags.api.HavenBagsAPI;
-import valorless.havenbags.datamodels.Data;
+// Temporarily commented out due to jitpack.io server error (521)
+// import valorless.havenbags.api.HavenBagsAPI;
+// import valorless.havenbags.datamodels.Data;
 
 /**
  * Utility manager and API entry point for creating, validating, and storing
@@ -444,6 +445,8 @@ public class RecipeUtil {
 		}
 
 		if (Main.getInstance().hasCustomPlugin("havenbags")) {
+			// Temporarily commented out due to jitpack.io server error (521) - will restore after upgrade
+			/*
 			Data bagData = HavenBagsAPI.getBagData(item);
 			if (bagData != null) {
 				Material material = bagData.getMaterial();
@@ -455,6 +458,7 @@ public class RecipeUtil {
 				allKeys.add("havenbags:" + size + material + modelData + texture);
 				return allKeys;
 			}
+			*/
 		}
 		return allKeys;
 	}

--- a/src/me/mehboss/utils/libs/ItemFactory.java
+++ b/src/me/mehboss/utils/libs/ItemFactory.java
@@ -54,10 +54,6 @@ import me.mehboss.utils.RecipeUtil.Ingredient;
 import me.mehboss.utils.RecipeUtil.Recipe;
 import me.mehboss.utils.libs.XItemStack.UnknownMaterialCondition;
 import me.mehboss.utils.libs.XItemStack.UnAcceptableMaterialCondition;
-import net.advancedplugins.ae.api.AEAPI;
-// Temporarily commented out due to jitpack.io server error (521)
-// import valorless.havenbags.api.HavenBagsAPI;
-// import valorless.havenbags.datamodels.Data;
 
 public class ItemFactory {
 
@@ -72,7 +68,7 @@ public class ItemFactory {
 	}
 
 	RecipeUtil getRecipeUtil() {
-		return Main.getInstance().recipeUtil;
+		return Main.getInstance().getRecipeUtil();
 	}
 
 	private void logError(String st, String recipe) {
@@ -81,23 +77,9 @@ public class ItemFactory {
 	}
 
 	private void logDebug(String st, String recipe) {
-		if (Main.getInstance().debug)
+		if (Main.getInstance().isDebug())
 			Logger.getLogger("Minecraft").log(Level.WARNING,
 					"[DEBUG][" + Main.getInstance().getName() + "][" + recipe.replaceAll(".Result", "") + "] " + st);
-	}
-
-	public boolean isHavenBag(String item) {
-		if (getConfig().isSet(item + ".Identifier")
-				&& getConfig().getString(item + ".Identifier").split("-")[0].contains("havenbags"))
-			return true;
-
-		return false;
-	}
-
-	boolean hasHavenBag() {
-		if (Main.getInstance().hasHavenBags)
-			return true;
-		return false;
 	}
 
 	boolean isCustomItem(String id) {
@@ -163,15 +145,6 @@ public class ItemFactory {
 
 		ItemStack i = hasItemDamage(item, type) ? handleItemDamage(item, type) : new ItemStack(type.get().get(), 1);
 		ItemMeta m = i.getItemMeta();
-
-		if (isHavenBag(item)) {
-			if (!(hasHavenBag())) {
-				logError("Error loading recipe..", item);
-				logError("Found a havenbag recipe, but no havenbags plugin found. Skipping recipe..", item);
-				return Optional.empty();
-			}
-			return Optional.of(handleBagCreation(i.getType(), 0, 0, "null", null, item));
-		}
 
 		// handle head textures
 		ItemStack texture = handleHeadTexture(path.getString(item + ".Item"));
@@ -370,13 +343,7 @@ public class ItemFactory {
 					String enchantment = breakdown[1].toLowerCase();
 					int lvl = Integer.parseInt(breakdown[2]);
 
-					if (Main.getInstance().hasAE && AEAPI.isAnEnchantment(enchantment)) {
-						i = AEAPI.applyEnchant(enchantment, lvl, i);
-						applied = true;
-						continue;
-					}
-
-					if (Main.getInstance().hasEE) {
+						if (Main.getInstance().isHasEE()) {
 						NamespacedKey enchantKey = NamespacedKey.fromString("minecraft:" + enchantment);
 						if (Enchantment.getByKey(enchantKey) != null) {
 							Enchantment enchant = Enchantment.getByKey(enchantKey);
@@ -882,7 +849,7 @@ public class ItemFactory {
 
 	// Temporarily commented out due to jitpack.io server error (521) - will restore after upgrade
 	/*
-	public ItemStack handleBagCreation(Material bagMaterial, int bagSize, int bagCMD, String canBind, String bagTexture,
+	public ItemStack handleBagCreation
 			String item) {
 
 		if (item != null) {

--- a/src/me/mehboss/utils/libs/ItemFactory.java
+++ b/src/me/mehboss/utils/libs/ItemFactory.java
@@ -55,8 +55,9 @@ import me.mehboss.utils.RecipeUtil.Recipe;
 import me.mehboss.utils.libs.XItemStack.UnknownMaterialCondition;
 import me.mehboss.utils.libs.XItemStack.UnAcceptableMaterialCondition;
 import net.advancedplugins.ae.api.AEAPI;
-import valorless.havenbags.api.HavenBagsAPI;
-import valorless.havenbags.datamodels.Data;
+// Temporarily commented out due to jitpack.io server error (521)
+// import valorless.havenbags.api.HavenBagsAPI;
+// import valorless.havenbags.datamodels.Data;
 
 public class ItemFactory {
 
@@ -879,6 +880,8 @@ public class ItemFactory {
 		return null;
 	}
 
+	// Temporarily commented out due to jitpack.io server error (521) - will restore after upgrade
+	/*
 	public ItemStack handleBagCreation(Material bagMaterial, int bagSize, int bagCMD, String canBind, String bagTexture,
 			String item) {
 
@@ -904,4 +907,5 @@ public class ItemFactory {
 		ItemStack bagItem = HavenBagsAPI.generateBagItem(bagData);
 		return bagItem;
 	}
+	*/
 }

--- a/src/me/mehboss/utils/libs/ItemManager.java
+++ b/src/me/mehboss/utils/libs/ItemManager.java
@@ -26,7 +26,7 @@ public class ItemManager {
 	}
 
 	static ItemFactory getItemFactory() {
-		return Main.getInstance().itemFactory;
+		return Main.getInstance().getItemFactory();
 	}
 	
 	/** Load all items from items folder */
@@ -105,14 +105,14 @@ public class ItemManager {
 
 		itemConfig = cfg;
 		String resultPath = cfg.isConfigurationSection(section + ".Result") ? section + ".Result" : section;
-		Optional<ItemStack> built = Main.getInstance().itemFactory.buildItem(resultPath, itemConfig);
+		Optional<ItemStack> built = Main.getInstance().getItemFactory().buildItem(resultPath, itemConfig);
 		if (!built.isPresent()) {
 			Main.getInstance().getLogger().warning("[CustomItemAPI] buildItem failed for section " + section);
 			return;
 		}
 
 		ItemStack it = built.get();
-		it = Main.getInstance().itemFactory.handleDurability(it, resultPath);
+		it = Main.getInstance().getItemFactory().handleDurability(it, resultPath);
 		int amount = cfg.isInt(resultPath + ".Amount") ? cfg.getInt(resultPath + ".Amount") : 1;
 		it.setAmount(amount);
 
@@ -120,10 +120,10 @@ public class ItemManager {
 		String id = cfg.getString(section + ".Identifier");
 		if (id != null && !id.isEmpty()) {
 			BY_IDENTIFIER.put(id, it.clone());
-			if (Main.getInstance().debug) {
+			if (Main.getInstance().isDebug()) {
 				Main.getInstance().getLogger().info("[CustomItemAPI] Loaded '" + section + "' (Identifier=" + id + ")");
 			}
-		} else if (Main.getInstance().debug) {
+		} else if (Main.getInstance().isDebug()) {
 			Main.getInstance().getLogger()
 					.info("[CustomItemAPI] Section '" + section + "' missing Identifier, skipping.");
 		}

--- a/src/me/mehboss/utils/libs/MetaChecks.java
+++ b/src/me/mehboss/utils/libs/MetaChecks.java
@@ -1,5 +1,6 @@
 package me.mehboss.utils.libs;
 
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.bukkit.inventory.ItemStack;
@@ -19,7 +20,7 @@ import me.mehboss.utils.RecipeUtil.Recipe;
  */
 public class MetaChecks {
 	private RecipeUtil getRecipeUtil() {
-		return Main.getInstance().recipeUtil;
+		return Main.getInstance().getRecipeUtil();
 	}
 
 	/**
@@ -73,6 +74,14 @@ public class MetaChecks {
 
 			// Checks displayname requirements only
 		} else {
+			// If no identifier is required, reject items that belong to a known custom plugin
+			// (Nexo, MythicMobs, ExecutableItems). A vanilla-material ingredient should
+			// never silently accept a custom item that happens to share the same material.
+			List<String> customKeys = getRecipeUtil().getKeysFromResult(item);
+			if (!customKeys.isEmpty()) {
+				logDebug("Ingredient has no identifier but item is a known custom item: " + customKeys, recipeName);
+				return false;
+			}
 			if (!recipe.hasIgnoreTag() && ingredient.hasItem() && ingredient.getItem().isSimilar(item))
 				return true;
 
@@ -142,7 +151,7 @@ public class MetaChecks {
 	}
 	
 	private void logDebug(String st, String recipeName) {
-		if (Main.getInstance().debug)
+		if (Main.getInstance().isDebug())
 			Logger.getLogger("Minecraft").log(Level.WARNING,
 					"[DEBUG][" + Main.getInstance().getName() + "][Metachecks][" + recipeName + "] " + st);
 	}

--- a/src/me/mehboss/utils/libs/XItemStack.java
+++ b/src/me/mehboss/utils/libs/XItemStack.java
@@ -39,7 +39,6 @@ import com.google.common.collect.Multimap;
 import de.tr7zw.changeme.nbtapi.NBT;
 import de.tr7zw.changeme.nbtapi.iface.ReadWriteNBT;
 import me.mehboss.recipe.Main;
-import net.advancedplugins.ae.api.AEAPI;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 
@@ -934,14 +933,6 @@ public final class XItemStack {
 				config.set("stored-enchants." + name, enchant.getValue());
 			}
 
-			if (Main.getInstance().hasAE) {
-				String book = AEAPI.getBookEnchantment(item);
-				int level = AEAPI.getBookEnchantmentLevel(item);
-
-				if (book != null) {
-					config.set("stored-enchants." + book, level);
-				}
-			}
 		}
 
 		private void handleBlockStateMeta(BlockStateMeta meta) {
@@ -1007,14 +998,6 @@ public final class XItemStack {
 				}
 
 				config.set(entry, enchant.getValue());
-			}
-			if (Main.getInstance().hasAE) {
-				Map<String, Integer> ae = AEAPI.getEnchantmentsOnItem(item);
-				if (ae != null) {
-					for (Map.Entry<String, Integer> e : ae.entrySet()) {
-						config.set("enchants." + e.getKey().toLowerCase(), e.getValue());
-					}
-				}
 			}
 		}
 
@@ -1380,10 +1363,7 @@ public final class XItemStack {
 						continue;
 					}
 
-					if (Main.getInstance().hasAE && AEAPI.isAnEnchantment(ench)) {
-						ItemStack book = AEAPI.createEnchantmentBook(ench, level, 100, 0, null);
-						item = book;
-					}
+
 				}
 			}
 		}
@@ -1395,9 +1375,7 @@ public final class XItemStack {
 					Optional<XEnchantment> enchant = XEnchantment.of(ench);
 					enchant.ifPresent(xEnchantment -> meta.addEnchant(xEnchantment.get(), enchants.getInt(ench), true));
 
-					if (Main.getInstance().hasAE && AEAPI.isAnEnchantment(ench)) {
-						item = AEAPI.applyEnchant(ench, enchants.getInt(ench), item);
-					}
+
 				}
 			} else if (config.getBoolean("glow")) {
 				meta.addEnchant(XEnchantment.UNBREAKING.get(), 1, false);


### PR DESCRIPTION
## Changes included

### Performance (100 concurrent players)
- `getRecipeFromKey()`: O(n) → O(1) with synchronized HashMap index
- `getRecipesFromType()`: O(n) + new HashMap → O(1) with EnumMap index
- `isCustomItem()`: for-loop → `Set.of().contains()`
- `EffectsManager`: YAML disk read per-event → in-memory cache (critical for combat)
- `EffectsManager`: triple `getRecipeFromKey()` per event → single lookup
- Nexo/ExecutableItems cached items now return `clone()` to prevent shared mutation bug

### Bug fixes
- Typo `CUSTOM_ITEM_IDENTIFER` fixed in 4 files (effects and block placement never worked)
- `BlockManager`/`EffectsManager`: stale RecipeUtil reference after `/crecipe reload` fixed
- `EffectsManager`: `ArrayIndexOutOfBoundsException` in effects loop fixed
- `SmithingManager`: `setResult(null)` on meta-check rejection (prevents re-use exploit)
- `SmithingManager`: items lost when inventory is full on smithing craft fixed
- `CommandGive`: negative/oversized amount exploit fixed (`/crecipe give player item -1`)
- Cache invalidation on `/crecipe reload` via `effectsManager.invalidateConfigCache()`