### PR TITLE
Refactor bag creation and bump HavenBags

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -252,7 +252,7 @@
 		<dependency>
 			<groupId>com.github.Valorless</groupId>
 			<artifactId>HavenBags</artifactId>
-			<version>156279014a</version>
+			<version>1.41.2</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/src/me/mehboss/utils/RecipeUtil.java
+++ b/src/me/mehboss/utils/RecipeUtil.java
@@ -336,7 +336,7 @@ public class RecipeUtil {
 					: null;
 			int size = !hasArgs || Integer.getInteger(split[1]) == null ? 1 : Integer.parseInt(split[1]);
 			int bagCMD = split.length < 4 || Integer.getInteger(split[3]) == null ? 0 : Integer.parseInt(split[3]);
-			String canBind = split.length >= 5 ? split[4] : "null";
+			boolean canBind = split.length >= 5 ? Boolean.valueOf(split[4]) : false;
 			String bagTexture = split.length >= 6 ? split[5] : "none";
 
 			if (!hasArgs || bagMaterial == null) {
@@ -347,7 +347,7 @@ public class RecipeUtil {
 
 			// havenbags:size:material:customModelData:canBind:texture
 			ItemStack bagItem = Main.getInstance().itemFactory.handleBagCreation(bagMaterial, size, bagCMD, canBind,
-					bagTexture, null);
+					bagTexture, null); //TODO: change null to ItemModel namespace:key -Valorless
 			return bagItem;
 
 		}

--- a/src/me/mehboss/utils/libs/ItemFactory.java
+++ b/src/me/mehboss/utils/libs/ItemFactory.java
@@ -56,7 +56,6 @@ import me.mehboss.utils.libs.XItemStack.UnknownMaterialCondition;
 import me.mehboss.utils.libs.XItemStack.UnAcceptableMaterialCondition;
 import net.advancedplugins.ae.api.AEAPI;
 import valorless.havenbags.api.HavenBagsAPI;
-import valorless.havenbags.datamodels.Data;
 
 public class ItemFactory {
 
@@ -169,7 +168,7 @@ public class ItemFactory {
 				logError("Found a havenbag recipe, but no havenbags plugin found. Skipping recipe..", item);
 				return Optional.empty();
 			}
-			return Optional.of(handleBagCreation(i.getType(), 0, 0, "null", null, item));
+			return Optional.of(handleBagCreation(i.getType(), item));
 		}
 
 		// handle head textures
@@ -878,30 +877,46 @@ public class ItemFactory {
 
 		return null;
 	}
+	
+	public ItemStack handleBagCreation(Material material, String item) {
+		String bagTexture = getConfig().isString(item + ".Bag-Texture") ? getConfig().getString(item + ".Bag-Texture")
+				: "none";
+		Boolean canBind = getConfig().getBoolean(item + ".Can-Bind");
+		int bagSize = getConfig().isInt(item + ".Bag-Size") ? getConfig().getInt(item + ".Bag-Size") : 9;
+		int bagCMD = 0;
 
-	public ItemStack handleBagCreation(Material bagMaterial, int bagSize, int bagCMD, String canBind, String bagTexture,
-			String item) {
+		if (Main.getInstance().serverVersionAtLeast(1, 14) && getConfig().isSet(item + ".Custom-Model-Data")
+				&& isInt(getConfig().getString(item + ".Custom-Model-Data"))) {
+			bagCMD = getConfig().getInt(item + ".Custom-Model-Data");
+		}
+		String itemModel = getConfig().contains(item + ".Item-Model", true) ? getConfig().getString(item + ".Item-Model")
+				: "none";
+		
+		return handleBagCreation(material, bagSize, bagCMD, canBind, bagTexture, itemModel);
+	
+	}
 
-		if (item != null) {
-			bagTexture = getConfig().isString(item + ".Bag-Texture") ? getConfig().getString(item + ".Bag-Texture")
-					: "none";
-			canBind = getConfig().getBoolean(item + ".Can-Bind") ? "null" : "ownerless";
-			bagSize = getConfig().isInt(item + ".Bag-Size") ? getConfig().getInt(item + ".Bag-Size") : 9;
-			bagCMD = 0;
-
-			if (Main.getInstance().serverVersionAtLeast(1, 14) && getConfig().isSet(item + ".Custom-Model-Data")
-					&& isInt(getConfig().getString(item + ".Custom-Model-Data"))) {
-				bagCMD = getConfig().getInt(item + ".Custom-Model-Data");
+	public ItemStack handleBagCreation(Material bagMaterial, int bagSize, int bagCMD, Boolean canBind, String bagTexture, String itemModel) {		
+		ItemStack bag = HavenBagsAPI.createUnusedBagItem(bagSize, canBind);
+		ItemMeta bagMeta = bag.getItemMeta();
+		if(bagCMD != 0)	bagMeta.setCustomModelData(bagCMD);
+		if(itemModel != null && !itemModel.equalsIgnoreCase("none")) {
+			if (Main.getInstance().serverVersionAtLeast(1, 21, 4)){
+				try {
+					bagMeta.setItemModel(NamespacedKey.fromString(itemModel));
+				} catch(NoSuchMethodError e) { // Backup to be safe.
+					logError("Your server version does not support item models, skipping item model application..", "");
+				} catch (Exception e) {
+					logError("Error occured while setting item model..", "");
+				}
 			}
 		}
-
-		Data bagData = new Data("null", canBind);
-		bagData.setSize(bagSize);
-		bagData.setMaterial(bagMaterial);
-		bagData.setTexture(bagTexture);
-		bagData.setModeldata(bagCMD);
-
-		ItemStack bagItem = HavenBagsAPI.generateBagItem(bagData);
-		return bagItem;
+		bag.setItemMeta(bagMeta);
+		
+		if(bagTexture != null && !bagTexture.equalsIgnoreCase("none")) {
+			HavenBagsAPI.setTexture(bag, bagTexture);
+		}
+		
+		return bag;
 	}
 }


### PR DESCRIPTION
Bump HavenBags dependency to 1.41.2 (Latest) and refactor havenbag item creation. RecipeUtil now parses canBind as a boolean and delegates to the updated ItemFactory.handleBagCreation overload. ItemFactory removes the old Data-based generation, adds new overloaded handleBagCreation(Material, String) and handleBagCreation(...) implementations that use HavenBagsAPI.createUnusedBagItem, apply custom model data, optional item model (NamespacedKey) with safe fallbacks, and set bag textures via HavenBagsAPI.setTexture. Also removed an unused import and simplified configuration-driven bag properties retrieval.

Main Changes:
- Refactored bag handling away from the havenbags datamodel "Data", and made canBind return a Boolean rather than a String, which caused issues for ownerless bags.
- Cleaned up the HavenBags part of ItemFactory, to make it easier to use all around <3
- Bumped the HavenBags version from an old Commit to 1.41.2, which is the latest public release.

Notes:
- You should likely include that the identifier must start with "havenbags" in order for it to be recognized, around the top of the wiki page [#HavenBags Recipes](https://github.com/mehboss/CustomRecipes/wiki/HavenBags-Recipes)
- Added a note in RecipeUtils to mind you to support ItemModel ;)
- I'll update HavenBags' API to fix the typo i found, but you dont have to change anything for that ^^

Please review the changes for anything I may've missed or any mistake I made.