### PR TITLE
fix: cancel craft event when vanilla ingredients match a CustomRecipes recipe

### DIFF
--- a/src/me/mehboss/crafting/CraftManager.java
+++ b/src/me/mehboss/crafting/CraftManager.java
@@ -573,8 +573,17 @@ public class CraftManager implements Listener {
 			return;
 		}
 
-		if (hasVanillaIngredients(inv, inv.getResult()))
+		if (hasVanillaIngredients(inv, inv.getResult())) {
+			org.bukkit.inventory.Recipe bukkit = e.getRecipe();
+			if (bukkit instanceof Keyed) {
+				NamespacedKey key = ((Keyed) bukkit).getKey();
+				if (key.getNamespace().equalsIgnoreCase(Main.getInstance().getName().toLowerCase())) {
+					logDebug("[hasVanillaIngredients] Blocking vanilla craft of CustomRecipes recipe: " + key.getKey(), "");
+					inv.setResult(new ItemStack(Material.AIR));
+				}
+			}
 			return;
+		}
 
 		logDebug("[handleCrafting] Fired craft event, beginning checks..", "", p.getUniqueId());
 		handleCraftingChecks(inv, p);


### PR DESCRIPTION
## Problem

When `hasVanillaIngredients()` returns `true`, the `handleCrafting` event handler exits early with a plain `return` — without cancelling the event or clearing the result. Bukkit's native recipe system then fires and delivers the registered result item, bypassing all custom name/tag/NBT checks.

**Reproducer:**
1. Create a shapeless recipe with a named ingredient (e.g. a MythicMobs boss drop with a custom display name).
2. Place plain, unnamed items of the same material in the crafting grid.
3. Without this fix, the result item is delivered as if the recipe matched.

## Fix

After detecting vanilla ingredients, check whether the matched Bukkit recipe was registered by CustomRecipes (by comparing its `NamespacedKey` namespace against the plugin name). If it was, set `inv.setResult(AIR)` before returning — so the craft is blocked.

```java
if (hasVanillaIngredients(inv, inv.getResult())) {
    org.bukkit.inventory.Recipe bukkit = e.getRecipe();
    if (bukkit instanceof Keyed) {
        NamespacedKey key = ((Keyed) bukkit).getKey();
        if (key.getNamespace().equalsIgnoreCase(Main.getInstance().getName().toLowerCase())) {
            logDebug("[hasVanillaIngredients] Blocking vanilla craft of CustomRecipes recipe: " + key.getKey(), "");
            inv.setResult(new ItemStack(Material.AIR));
        }
    }
    return;
}
```

This preserves existing behaviour for truly vanilla recipes (non-CustomRecipes namespace) while correctly blocking recipes that require named/tagged ingredients when plain items are used.